### PR TITLE
Add PORT peripheral push-pull I/O pin abstraction

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/port.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/port.h
@@ -244,6 +244,17 @@ class PORT {
     }
 
     /**
+     * \brief Configure a pin to act as a push-pull I/O pin.
+     *
+     * \param[in] mask The mask identifying the pin to be configured to act as a push-pull
+     *            I/O pin.
+     */
+    void configure_pin_as_push_pull_io( std::uint8_t mask ) noexcept
+    {
+        dirset = mask;
+    }
+
+    /**
      * \brief Enable a pin's internal pull-up resistor.
      *
      * \param[in] n The pin number of the pin whose internal pull-up resistor is to be
@@ -275,6 +286,38 @@ class PORT {
     auto state( std::uint8_t mask ) const noexcept -> std::uint8_t
     {
         return in & mask;
+    }
+
+    /**
+     * \brief Transition a push-pull I/O pin to the high state.
+     *
+     * \param[in] mask The mask identifying the push-pull I/O pin to transition to the
+     *            high state.
+     */
+    void transition_push_pull_io_to_high( std::uint8_t mask ) noexcept
+    {
+        outset = mask;
+    }
+
+    /**
+     * \brief Transition a push-pull I/O pin to the low state.
+     *
+     * \param[in] mask The mask identifying the push-pull I/O pin to transition to the low
+     *            state.
+     */
+    void transition_push_pull_io_to_low( std::uint8_t mask ) noexcept
+    {
+        outclr = mask;
+    }
+
+    /**
+     * \brief Toggle the state of a push-pull I/O pin.
+     *
+     * \param[in] mask The mask identifying the push-pull I/O pin to toggle the state of.
+     */
+    void toggle_push_pull_io( std::uint8_t mask ) noexcept
+    {
+        outtgl = mask;
     }
 };
 


### PR DESCRIPTION
Resolves #45 (Add PORT peripheral push-pull I/O pin abstraction).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
