### PR TITLE
Add PORT peripheral open-drain I/O pin abstraction

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/port.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/port.h
@@ -255,9 +255,9 @@ class PORT {
     }
 
     /**
-     * \brief Configure a pin to act as a open-drain I/O pin.
+     * \brief Configure a pin to act as an open-drain I/O pin.
      *
-     * \param[in] mask The mask identifying the pin to be configured to act as a
+     * \param[in] mask The mask identifying the pin to be configured to act as an
      *            open-drain I/O pin.
      */
     void configure_pin_as_open_drain_io( std::uint8_t mask ) noexcept
@@ -311,7 +311,7 @@ class PORT {
     }
 
     /**
-     * \brief Transition a open-drain I/O pin to the high state.
+     * \brief Transition an open-drain I/O pin to the high state.
      *
      * \param[in] mask The mask identifying the open-drain I/O pin to transition to the
      *            high state.
@@ -333,7 +333,7 @@ class PORT {
     }
 
     /**
-     * \brief Transition a open-drain I/O pin to the low state.
+     * \brief Transition an open-drain I/O pin to the low state.
      *
      * \param[in] mask The mask identifying the open-drain I/O pin to transition to the
      *            low state.
@@ -354,7 +354,7 @@ class PORT {
     }
 
     /**
-     * \brief Toggle the state of a open-drain I/O pin.
+     * \brief Toggle the state of an open-drain I/O pin.
      *
      * \param[in] mask The mask identifying the open-drain I/O pin to toggle the state of.
      */

--- a/include/picolibrary/microchip/megaavr0/peripheral/port.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/port.h
@@ -255,6 +255,17 @@ class PORT {
     }
 
     /**
+     * \brief Configure a pin to act as a open-drain I/O pin.
+     *
+     * \param[in] mask The mask identifying the pin to be configured to act as a
+     *            open-drain I/O pin.
+     */
+    void configure_pin_as_open_drain_io( std::uint8_t mask ) noexcept
+    {
+        outclr = mask;
+    }
+
+    /**
      * \brief Enable a pin's internal pull-up resistor.
      *
      * \param[in] n The pin number of the pin whose internal pull-up resistor is to be
@@ -300,6 +311,17 @@ class PORT {
     }
 
     /**
+     * \brief Transition a open-drain I/O pin to the high state.
+     *
+     * \param[in] mask The mask identifying the open-drain I/O pin to transition to the
+     *            high state.
+     */
+    void transition_open_drain_io_to_high( std::uint8_t mask ) noexcept
+    {
+        dirclr = mask;
+    }
+
+    /**
      * \brief Transition a push-pull I/O pin to the low state.
      *
      * \param[in] mask The mask identifying the push-pull I/O pin to transition to the low
@@ -311,6 +333,17 @@ class PORT {
     }
 
     /**
+     * \brief Transition a open-drain I/O pin to the low state.
+     *
+     * \param[in] mask The mask identifying the open-drain I/O pin to transition to the
+     *            low state.
+     */
+    void transition_open_drain_io_to_low( std::uint8_t mask ) noexcept
+    {
+        dirset = mask;
+    }
+
+    /**
      * \brief Toggle the state of a push-pull I/O pin.
      *
      * \param[in] mask The mask identifying the push-pull I/O pin to toggle the state of.
@@ -318,6 +351,16 @@ class PORT {
     void toggle_push_pull_io( std::uint8_t mask ) noexcept
     {
         outtgl = mask;
+    }
+
+    /**
+     * \brief Toggle the state of a open-drain I/O pin.
+     *
+     * \param[in] mask The mask identifying the open-drain I/O pin to toggle the state of.
+     */
+    void toggle_open_drain_io( std::uint8_t mask ) noexcept
+    {
+        dirtgl = mask;
     }
 };
 


### PR DESCRIPTION
Resolves #46 (Add PORT peripheral open-drain I/O pin abstraction).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
