### PR TITLE
Add VPORT peripheral open-drain I/O pin abstraction

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/vport.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/vport.h
@@ -91,6 +91,17 @@ class VPORT {
     }
 
     /**
+     * \brief Configure a pin to act as an open-drain I/O pin.
+     *
+     * \param[in] mask The mask identifying the pin to be configured to act as an
+     *            open-drain I/O pin.
+     */
+    void configure_pin_as_open_drain_io( std::uint8_t mask ) noexcept
+    {
+        out &= ~mask;
+    }
+
+    /**
      * \brief Get the state of a pin.
      *
      * \param[in] mask The mask identifying the pin whose state is to be gotten.
@@ -114,6 +125,17 @@ class VPORT {
     }
 
     /**
+     * \brief Transition an open-drain I/O pin to the high state.
+     *
+     * \param[in] mask The mask identifying the open-drain I/O pin to transition to the
+     *            high state.
+     */
+    void transition_open_drain_io_to_high( std::uint8_t mask ) noexcept
+    {
+        dir &= ~mask;
+    }
+
+    /**
      * \brief Transition a push-pull I/O pin to the low state.
      *
      * \param[in] mask The mask identifying the push-pull I/O pin to transition to the low
@@ -125,6 +147,17 @@ class VPORT {
     }
 
     /**
+     * \brief Transition an open-drain I/O pin to the low state.
+     *
+     * \param[in] mask The mask identifying the open-drain I/O pin to transition to the
+     *            low state.
+     */
+    void transition_open_drain_io_to_low( std::uint8_t mask ) noexcept
+    {
+        dir |= mask;
+    }
+
+    /**
      * \brief Toggle the state of a push-pull I/O pin.
      *
      * \param[in] mask The mask identifying the push-pull I/O pin to toggle the state of.
@@ -132,6 +165,16 @@ class VPORT {
     void toggle_push_pull_io( std::uint8_t mask ) noexcept
     {
         out ^= mask;
+    }
+
+    /**
+     * \brief Toggle the state of an open-drain I/O pin.
+     *
+     * \param[in] mask The mask identifying the open-drain I/O pin to toggle the state of.
+     */
+    void toggle_open_drain_io( std::uint8_t mask ) noexcept
+    {
+        dir ^= mask;
     }
 };
 


### PR DESCRIPTION
Resolves #49 (Add VPORT peripheral open-drain I/O pin abstraction).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
