### PR TITLE
Add ATmega4809 multiplexed signals skeleton

### DIFF
--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809.h
@@ -1,0 +1,44 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Multiplexed_Signals::ATmega4809 interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_ATMEGA4809_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_ATMEGA4809_H
+
+/**
+ * \brief Microchip megaAVR 0-series ATmega4809 multiplexed signals facilities.
+ *
+ * \attention The contents of this namespace should never be used directly. Instead, set
+ *            the `-mmcu` compiler flag to `atmega4809` and use them through the
+ *            picolibrary::Microchip::megaAVR0::Multiplexed_Signals namespace.
+ */
+namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals::ATmega4809 {
+} // namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals::ATmega4809
+
+namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals {
+
+#ifdef __AVR_ATmega4809__
+using namespace ATmega4809;
+#endif // __AVR_ATmega4809__
+
+} // namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_ATMEGA4809_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
     "picolibrary/microchip/megaavr0.cc"
     "picolibrary/microchip/megaavr0/gpio.cc"
     "picolibrary/microchip/megaavr0/multiplexed_signals.cc"
+    "picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809.cc"
     "picolibrary/microchip/megaavr0/peripheral.cc"
     "picolibrary/microchip/megaavr0/peripheral/atmega4809.cc"
     "picolibrary/microchip/megaavr0/peripheral/clkctrl.cc"

--- a/source/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809.cc
+++ b/source/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809.cc
@@ -17,18 +17,8 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::megaAVR0::Multiplexed_Signals interface.
+ * \brief picolibrary::Microchip::megaAVR0::Multiplexed_Signals::ATmega4809
+ *        implementation.
  */
-
-#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_H
-#define PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_H
 
 #include "picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809.h"
-
-/**
- * \brief Microchip megaAVR 0-series multiplexed signals facilities.
- */
-namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals {
-} // namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals
-
-#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_H


### PR DESCRIPTION
Resolves #87 (Add ATmega4809 multiplexed signals skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
