### PR TITLE
Explicitly set format CI job clang-format version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v2
+            - name: Configure dependencies
+              shell: bash
+              run: sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100 && sudo update-alternatives --set clang-format /usr/bin/clang-format-10
             - name: Format
               shell: bash
               run: ./ci/format

--- a/include/picolibrary/microchip/megaavr0/register.h
+++ b/include/picolibrary/microchip/megaavr0/register.h
@@ -288,10 +288,10 @@ class Protected_Register {
             "out %[cpu_ccp_address], %[cpu_ccp_unlock_protected_io_registers] \n\t"
             "sts %[protected_register_address], %[protected_register_data]"
             :
-            : [cpu_ccp_address] "I"( CPU_CCP_ADDRESS ),
-              [cpu_ccp_unlock_protected_io_registers] "d"( CPU_CCP_UNLOCK_PROTECTED_IO_REGISTERS ),
-              [protected_register_address] "n"( &m_protected_register ),
-              [protected_register_data] "r"( data ) );
+            : [ cpu_ccp_address ] "I"( CPU_CCP_ADDRESS ),
+              [ cpu_ccp_unlock_protected_io_registers ] "d"( CPU_CCP_UNLOCK_PROTECTED_IO_REGISTERS ),
+              [ protected_register_address ] "n"( &m_protected_register ),
+              [ protected_register_data ] "r"( data ) );
     }
 };
 


### PR DESCRIPTION
Resolves #111 (Explicitly set format CI job clang-format version).

The GitHub actions Ubuntu 20.04 image's default clang-format version has
changed from 10 to 11. The format CI job now explicitly sets the
clang-format version to 10 for consistency with the development
environment.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
