### PR TITLE
Relocate CLKCTRL peripheral member types

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h
@@ -831,78 +831,6 @@ class CLKCTRL {
     };
 
     /**
-     * \brief MCLKCTRLA.
-     */
-    MCLKCTRLA mclkctrla;
-
-    /**
-     * \brief MCLKCTRLB.
-     */
-    MCLKCTRLB mclkctrlb;
-
-    /**
-     * \brief MCLKLOCK.
-     */
-    MCLKLOCK mclklock;
-
-    /**
-     * \brief MCLKSTATUS.
-     */
-    MCLKSTATUS mclkstatus;
-
-    /**
-     * \brief Reserved registers (offset 0x04-0x0F).
-     */
-    Reserved_Register<std::uint8_t> const reserved_0x04_0x0F[ ( 0x0F - 0x04 ) + 1 ];
-
-    /**
-     * \brief OSC20MCTRLA.
-     */
-    OSC20MCTRLA osc20mctrla;
-
-    /**
-     * \brief OSC20MCALIBA.
-     */
-    OSC20MCALIBA osc20mcaliba;
-
-    /**
-     * \brief OSC20MCALIBB.
-     */
-    OSC20MCALIBB osc20mcalibb;
-
-    /**
-     * \brief Reserved registers (offset 0x13-0x17).
-     */
-    Reserved_Register<std::uint8_t> const reserved_0x13_0x17[ ( 0x17 - 0x13 ) + 1 ];
-
-    /**
-     * \brief OSC32KCTRLA.
-     */
-    OSC32KCTRLA osc32kctrla;
-
-    /**
-     * \brief Reserved registers (offset 0x19-0x1B).
-     */
-    Reserved_Register<std::uint8_t> const reserved_0x19_0x1B[ ( 0x1B - 0x19 ) + 1 ];
-
-    /**
-     * \brief XOSC32KCTRLA.
-     */
-    XOSC32KCTRLA xosc32kctrla;
-
-    CLKCTRL() = delete;
-
-    CLKCTRL( CLKCTRL && ) = delete;
-
-    CLKCTRL( CLKCTRL const & ) = delete;
-
-    ~CLKCTRL() = delete;
-
-    auto operator=( CLKCTRL && ) = delete;
-
-    auto operator=( CLKCTRL const & ) = delete;
-
-    /**
      * \brief Clock source.
      */
     enum class Source : std::uint8_t {
@@ -978,6 +906,78 @@ class CLKCTRL {
         NORMAL    = 0b0 << XOSC32KCTRLA::Bit::RUNSTDBY, ///< Normal.
         FORCED_ON = 0b1 << XOSC32KCTRLA::Bit::RUNSTDBY, ///< Forced on.
     };
+
+    /**
+     * \brief MCLKCTRLA.
+     */
+    MCLKCTRLA mclkctrla;
+
+    /**
+     * \brief MCLKCTRLB.
+     */
+    MCLKCTRLB mclkctrlb;
+
+    /**
+     * \brief MCLKLOCK.
+     */
+    MCLKLOCK mclklock;
+
+    /**
+     * \brief MCLKSTATUS.
+     */
+    MCLKSTATUS mclkstatus;
+
+    /**
+     * \brief Reserved registers (offset 0x04-0x0F).
+     */
+    Reserved_Register<std::uint8_t> const reserved_0x04_0x0F[ ( 0x0F - 0x04 ) + 1 ];
+
+    /**
+     * \brief OSC20MCTRLA.
+     */
+    OSC20MCTRLA osc20mctrla;
+
+    /**
+     * \brief OSC20MCALIBA.
+     */
+    OSC20MCALIBA osc20mcaliba;
+
+    /**
+     * \brief OSC20MCALIBB.
+     */
+    OSC20MCALIBB osc20mcalibb;
+
+    /**
+     * \brief Reserved registers (offset 0x13-0x17).
+     */
+    Reserved_Register<std::uint8_t> const reserved_0x13_0x17[ ( 0x17 - 0x13 ) + 1 ];
+
+    /**
+     * \brief OSC32KCTRLA.
+     */
+    OSC32KCTRLA osc32kctrla;
+
+    /**
+     * \brief Reserved registers (offset 0x19-0x1B).
+     */
+    Reserved_Register<std::uint8_t> const reserved_0x19_0x1B[ ( 0x1B - 0x19 ) + 1 ];
+
+    /**
+     * \brief XOSC32KCTRLA.
+     */
+    XOSC32KCTRLA xosc32kctrla;
+
+    CLKCTRL() = delete;
+
+    CLKCTRL( CLKCTRL && ) = delete;
+
+    CLKCTRL( CLKCTRL const & ) = delete;
+
+    ~CLKCTRL() = delete;
+
+    auto operator=( CLKCTRL && ) = delete;
+
+    auto operator=( CLKCTRL const & ) = delete;
 
     /**
      * \copydoc picolibrary::Microchip::megaAVR0::Peripheral::CLKCTRL::MCLKCTRLA::source()


### PR DESCRIPTION
Resolves #117 (Relocate CLKCTRL peripheral member types).

Some CLKCTRL peripheral member types were located after the CLKCTRL
peripheral's register member variables and special member function
deletions which was not consistent with the picolibrary convention
(member types appear before member variables and member functions).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
