### PR TITLE
Add asynchronous serial 8-N-1 transmitter interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter_8_n_1/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter_8_n_1/CMakeLists.txt
@@ -13,10 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR0::Asynchronous_Serial interactive tests
-#       CMake rules.
-
-# build the picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1
-# interactive tests
-add_subdirectory( transmitter_8_n_1 )
+# File: test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter_8_n_1/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #126 (Add asynchronous serial 8-N-1 transmitter interactive
testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
