### PR TITLE
iAdd asynchronous serial clock configuration clock generator operating speed type alias

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -45,9 +45,14 @@ namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial {
  */
 struct Clock_Configuration {
     /**
+     * \brief Clock generator operating speed.
+     */
+    using Operating_Speed = Peripheral::USART::Operating_Speed;
+
+    /**
      * \brief The clock generator operating speed.
      */
-    Peripheral::USART::Operating_Speed operating_speed;
+    Operating_Speed operating_speed;
 
     /**
      * \brief The clock generator scaling factor.


### PR DESCRIPTION
Resolves #132 (Add asynchronous serial clock configuration clock
generator operating speed type alias).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
