### PR TITLE
Fix asynchronous serial basic transmitter incomplete data transmission

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -196,6 +196,8 @@ class Basic_Transmitter {
     void disable() noexcept
     {
         if ( m_usart ) {
+            while ( not m_usart->transmission_complete() ) {}
+
             m_usart->disable_transmitter();
         } // if
     }


### PR DESCRIPTION
Resolves #134 (Fix asynchronous serial basic transmitter incomplete data
transmission).

Destruction of a
::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Basic_Transmitter
previously terminated any ongoing data transmission due to the
destruction of the TXD pin, which resulted in the pin being configured
as an input. Destruction of the TXD pin (and disabling of the
transmitter) is now delayed until any ongoing data transmission is
completed.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
