### PR TITLE
Add Microchip megaAVR 0-series GPIO push-pull I/O pin interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/push_pull_io_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/push_pull_io_pin/CMakeLists.txt
@@ -13,18 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr0/gpio/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR0::GPIO interactive tests CMake rules.
-
-# build the picolibrary::Microchip::megaAVR0::GPIO::Input_Pin interactive tests
-add_subdirectory( input_pin )
-
-# build the picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin
-# interactive tests
-add_subdirectory( internally_pulled_up_input_pin )
-
-# build the picolibrary::Microchip::megaAVR0::GPIO::Open_Drain_IO_Pin interactive tests
-add_subdirectory( open_drain_io_pin )
-
-# build the picolibrary::Microchip::megaAVR0::GPIO::Push_Pull_IO_Pin interactive tests
-add_subdirectory( push_pull_io_pin )
+# File: test/interactive/picolibrary/microchip/megaavr0/gpio/push_pull_io_pin/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR0::GPIO::Push_Pull_IO_Pin interactive tests
+#       CMake rules.


### PR DESCRIPTION
Resolves #147 (Add Microchip megaAVR 0-series GPIO push-pull I/O pin
interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
