### PR TITLE
Add PORTMUX peripheral SPI routing abstraction

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/portmux.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/portmux.h
@@ -542,6 +542,26 @@ class PORTMUX {
     auto operator=( PORTMUX const & ) = delete;
 
     /**
+     * \brief Get the SPI0 routing configuration.
+     *
+     * \return The SPI0 routing configuration.
+     */
+    auto spi0_route() const noexcept
+    {
+        return twispiroutea.spi0_route();
+    }
+
+    /**
+     * \brief Set the SPI0 routing configuration.
+     *
+     * \param[in] route The desired SPI0 routing configuration.
+     */
+    void set_spi0_route( SPI_Route route ) noexcept
+    {
+        twispiroutea.set_spi0_route( route );
+    }
+
+    /**
      * \brief Get the USART0 routing configuration.
      *
      * \return The USART0 routing configuration.


### PR DESCRIPTION
Resolves #177 (Add PORTMUX peripheral SPI routing abstraction).

Should have been added by #176 (Add PORTMUX peripheral SPI routing
abstraction).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
