### PR TITLE
Add Microchip megaAVR 0-series SPI interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr0/spi/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/spi/CMakeLists.txt
@@ -13,14 +13,5 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr0/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR0 interactive tests CMake rules.
-
-# build the picolibrary::Microchip::megaAVR0::Asynchronous_Serial interactive tests
-add_subdirectory( asynchronous_serial )
-
-# build the picolibrary::Microchip::megaAVR0::GPIO interactive tests
-add_subdirectory( gpio )
-
-# build the picolibrary::Microchip::megaAVR0::SPI interactive tests
-add_subdirectory( spi )
+# File: test/interactive/picolibrary/microchip/megaavr0/spi/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR0::SPI interactive tests CMake rules.


### PR DESCRIPTION
Resolves #169 (Add Microchip megaAVR 0-series SPI interactive testing
skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
