### PR TITLE
Add Microchip megaAVR 0-series fixed configuration SPI controller interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/megaavr0/spi/fixed_configuration_controller/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/spi/fixed_configuration_controller/CMakeLists.txt
@@ -13,12 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/megaavr0/spi/CMakeLists.txt
-# Description: picolibrary::Microchip::megaAVR0::SPI interactive tests CMake rules.
-
-# build the picolibrary::Microchip::megaAVR0::SPI::Controller interactive tests
-add_subdirectory( controller )
-
-# build the picolibrary::Microchip::megaAVR0::SPI::Fixed_Configuration_Controller
-# interactive tests
-add_subdirectory( fixed_configuration_controller )
+# File: test/interactive/picolibrary/microchip/megaavr0/spi/fixed_configuration_controller/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR0::SPI::Fixed_Configuration_Controller
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #193 (Add Microchip megaAVR 0-series fixed configuration SPI
controller interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
