### PR TITLE
Fix TWI peripheral addressing complete logic

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/twi.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/twi.h
@@ -471,7 +471,7 @@ class TWI {
          */
         auto addressing_complete() const noexcept -> bool
         {
-            return *this & Mask::WIF;
+            return *this & ( Mask::WIF | Mask::RIF );
         }
 
         /**


### PR DESCRIPTION
Resolves #224 (Fix TWI peripheral addressing complete logic).

picolibrary::Microchip::megaAVR0::I2C::Basic_Controller::address()
previously hanged when a device was addressed with operation set to
picolibrary::I2C::Operation::READ and the device responded with an ACK.

This hang was due to flawed logic in
picolibrary::Microchip::megaAVR0::Peripheral::TWI::addressing_complete()
which previously reported that addressing was complete when HSTATUS.WIF
was set. Changing the function to report that addressing is complete
when either HSTATUS.WIF or HSTATUS.RIF are set prevents the hang. The
"Transmitting Address Packets" section of the ATmega4808/ATmega4809
datasheet does not stat that HSTATUS.RIF is set in this scenario, but
the "Receiving Data Packets" section does state that HSTATUS.RIF is set
when the data is received after the device has been addressed.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
