### PR TITLE
Undefine avr-libc macros that clash with library features

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/atmega4809.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/atmega4809.h
@@ -40,6 +40,10 @@
  */
 namespace picolibrary::Microchip::megaAVR0::Peripheral::ATmega4809 {
 
+#ifdef VPORTA
+#undef VPORTA
+#endif // VPORTA
+
 /**
  * \brief VPORTA.
  *
@@ -48,6 +52,10 @@ namespace picolibrary::Microchip::megaAVR0::Peripheral::ATmega4809 {
  *            picolibrary::Microchip::megaAVR0::Peripheral::VPORTA.
  */
 using VPORTA = VPORT_Instance<0x0000>;
+
+#ifdef VPORTB
+#undef VPORTB
+#endif // VPORTB
 
 /**
  * \brief VPORTB.
@@ -58,6 +66,10 @@ using VPORTA = VPORT_Instance<0x0000>;
  */
 using VPORTB = VPORT_Instance<0x0004>;
 
+#ifdef VPORTC
+#undef VPORTC
+#endif // VPORTC
+
 /**
  * \brief VPORTC.
  *
@@ -66,6 +78,10 @@ using VPORTB = VPORT_Instance<0x0004>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::VPORTC.
  */
 using VPORTC = VPORT_Instance<0x0008>;
+
+#ifdef VPORTD
+#undef VPORTD
+#endif // VPORTD
 
 /**
  * \brief VPORTD.
@@ -76,6 +92,10 @@ using VPORTC = VPORT_Instance<0x0008>;
  */
 using VPORTD = VPORT_Instance<0x000C>;
 
+#ifdef VPORTE
+#undef VPORTE
+#endif // VPORTE
+
 /**
  * \brief VPORTE.
  *
@@ -84,6 +104,10 @@ using VPORTD = VPORT_Instance<0x000C>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::VPORTE.
  */
 using VPORTE = VPORT_Instance<0x0010>;
+
+#ifdef VPORTF
+#undef VPORTF
+#endif // VPORTF
 
 /**
  * \brief VPORTF.
@@ -103,6 +127,10 @@ using VPORTF = VPORT_Instance<0x0014>;
  */
 using CLKCTRL0 = CLKCTRL_Instance<0x0060>;
 
+#ifdef PORTA
+#undef PORTA
+#endif // PORTA
+
 /**
  * \brief PORTA.
  *
@@ -111,6 +139,10 @@ using CLKCTRL0 = CLKCTRL_Instance<0x0060>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::PORTA.
  */
 using PORTA = PORT_Instance<0x0400>;
+
+#ifdef PORTB
+#undef PORTB
+#endif // PORTB
 
 /**
  * \brief PORTB.
@@ -121,6 +153,10 @@ using PORTA = PORT_Instance<0x0400>;
  */
 using PORTB = PORT_Instance<0x0420>;
 
+#ifdef PORTC
+#undef PORTC
+#endif // PORTC
+
 /**
  * \brief PORTC.
  *
@@ -129,6 +165,10 @@ using PORTB = PORT_Instance<0x0420>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::PORTC.
  */
 using PORTC = PORT_Instance<0x0440>;
+
+#ifdef PORTD
+#undef PORTD
+#endif // PORTD
 
 /**
  * \brief PORTD.
@@ -139,6 +179,10 @@ using PORTC = PORT_Instance<0x0440>;
  */
 using PORTD = PORT_Instance<0x0460>;
 
+#ifdef PORTE
+#undef PORTE
+#endif // PORTE
+
 /**
  * \brief PORTE.
  *
@@ -147,6 +191,10 @@ using PORTD = PORT_Instance<0x0460>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::PORTE.
  */
 using PORTE = PORT_Instance<0x0480>;
+
+#ifdef PORTF
+#undef PORTF
+#endif // PORTF
 
 /**
  * \brief PORTF.
@@ -166,6 +214,10 @@ using PORTF = PORT_Instance<0x04A0>;
  */
 using PORTMUX0 = PORTMUX_Instance<0x05E0>;
 
+#ifdef USART0
+#undef USART0
+#endif // USART0
+
 /**
  * \brief USART0.
  *
@@ -174,6 +226,10 @@ using PORTMUX0 = PORTMUX_Instance<0x05E0>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::USART0.
  */
 using USART0 = USART_Instance<0x0800>;
+
+#ifdef USART1
+#undef USART1
+#endif // USART1
 
 /**
  * \brief USART1.
@@ -184,6 +240,10 @@ using USART0 = USART_Instance<0x0800>;
  */
 using USART1 = USART_Instance<0x0820>;
 
+#ifdef USART2
+#undef USART2
+#endif // USART2
+
 /**
  * \brief USART2.
  *
@@ -192,6 +252,10 @@ using USART1 = USART_Instance<0x0820>;
  *            picolibrary::Microchip::megaAVR0::Peripheral::USART2.
  */
 using USART2 = USART_Instance<0x0840>;
+
+#ifdef USART3
+#undef USART3
+#endif // USART3
 
 /**
  * \brief USART3.

--- a/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h
@@ -31,6 +31,10 @@
 
 namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
+#ifdef CLKCTRL
+#undef CLKCTRL
+#endif // CLKCTRL
+
 /**
  * \brief Microchip megaAVR 0-series Clock Controller (CLKCTRL) peripheral.
  */

--- a/include/picolibrary/microchip/megaavr0/peripheral/portmux.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/portmux.h
@@ -31,6 +31,10 @@
 
 namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
+#ifdef PORTMUX
+#undef PORTMUX
+#endif // PORTMUX
+
 /**
  * \brief Microchip megaAVR 0-series Port Multiplexer (PORTMUX) peripheral.
  */
@@ -186,6 +190,22 @@ class PORTMUX {
      */
     class USARTROUTEA : public Register<std::uint8_t> {
       public:
+#ifdef USART0
+#undef USART0
+#endif // USART0
+
+#ifdef USART1
+#undef USART1
+#endif // USART1
+
+#ifdef USART2
+#undef USART2
+#endif // USART2
+
+#ifdef USART3
+#undef USART3
+#endif // USART3
+
         /**
          * \brief Field sizes.
          */
@@ -320,6 +340,14 @@ class PORTMUX {
      */
     class TWISPIROUTEA : public Register<std::uint8_t> {
       public:
+#ifdef SPI0
+#undef SPI0
+#endif // SPI0
+
+#ifdef TWI0
+#undef TWI0
+#endif // TWI0
+
         /**
          * \brief Field sizes.
          */
@@ -413,6 +441,10 @@ class PORTMUX {
      */
     class TCAROUTEA : public Register<std::uint8_t> {
       public:
+#ifdef TCA0
+#undef TCA0
+#endif // TCA0
+
         /**
          * \brief Field sizes.
          */
@@ -463,6 +495,22 @@ class PORTMUX {
      */
     class TCBROUTEA : public Register<std::uint8_t> {
       public:
+#ifdef TCB0
+#undef TCB0
+#endif // TCB0
+
+#ifdef TCB1
+#undef TCB1
+#endif // TCB1
+
+#ifdef TCB2
+#undef TCB2
+#endif // TCB2
+
+#ifdef TCB3
+#undef TCB3
+#endif // TCB3
+
         /**
          * \brief Field sizes.
          */


### PR DESCRIPTION
Resolves #244 (Undefine avr-libc macros that clash with library
features).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
