### PR TITLE
Remove C++ files existence check from CI format script

### DIFF
--- a/ci/format
+++ b/ci/format
@@ -64,10 +64,8 @@ function ensure_formatting_style_is_consistent()
 {
     local cpp_files; mapfile -t cpp_files < <( git -C "$repository" ls-files '*.h' '*.h.in' '*.cc' '*.cc.in' | xargs -r -d '\n' -I '{}' find "$repository/{}" ); readonly cpp_files
 
-    if [[ "${#cpp_files[@]}" -ne 0 ]]; then
-        if ! ( cd "$repository" && clang-format -i --verbose "${cpp_files[@]}" && git -C "$repository" diff --exit-code ); then
-            abort
-        fi
+    if ! ( cd "$repository" && clang-format -i --verbose "${cpp_files[@]}" && git -C "$repository" diff --exit-code ); then
+        abort
     fi
 }
 


### PR DESCRIPTION
Resolves #266 (Remove C++ files existence check from CI format script).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
