### PR TITLE
Explicitly delete asynchronous serial 8-N-1 transmitter copy assignment operator

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -266,6 +266,8 @@ class Transmitter_8_N_1 : private Transmitter<std::uint8_t> {
      */
     auto operator=( Transmitter_8_N_1 && expression ) noexcept -> Transmitter_8_N_1 & = default;
 
+    auto operator=( Transmitter_8_N_1 const & ) = delete;
+
     using Transmitter<std::uint8_t>::initialize;
     using Transmitter<std::uint8_t>::transmit;
 };


### PR DESCRIPTION
Resolves #282 (Explicitly delete asynchronous serial 8-N-1 transmitter
copy assignment operator).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
