### PR TITLE
Remove asynchronous serial clock configuration operating speed member type alias

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -45,14 +45,9 @@ namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial {
  */
 struct Clock_Configuration {
     /**
-     * \brief Clock generator operating speed.
-     */
-    using Operating_Speed = Peripheral::USART::Operating_Speed;
-
-    /**
      * \brief The clock generator operating speed.
      */
-    Operating_Speed operating_speed;
+    Peripheral::USART::Operating_Speed operating_speed;
 
     /**
      * \brief The clock generator scaling factor.

--- a/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/main.cc
+++ b/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/main.cc
@@ -26,6 +26,7 @@
 #include "picolibrary/microchip/megaavr0/clock.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/asynchronous_serial/stream.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -34,12 +35,12 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Asynchronous_Serial::Stream::hello_world;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -59,7 +60,7 @@ int main()
 
     hello_world<Unbuffered_Output_Stream>( Transmitter_8_N_1{
         TRANSMITTER_USART::instance(),
-        { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+        { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
           .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
 
     for ( ;; ) {}

--- a/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/main.cc
@@ -31,6 +31,7 @@
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/microchip/mcp23008.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -40,7 +41,6 @@ using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::I2C::Address;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -50,6 +50,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::TWI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::TWI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::MCP23008::state;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -71,7 +72,7 @@ int main()
 
     state<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     TWI::SDA_Hold_Time::CONTROLLER_SDA_HOLD_TIME,

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/microchip/mcp23008.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -42,7 +43,6 @@ using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::I2C::Address;
 using ::picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -52,6 +52,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::TWI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::TWI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::MCP23008::toggle;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -73,7 +74,7 @@ int main()
 
     toggle<Unbuffered_Output_Stream, Open_Drain_IO_Pin>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     TWI::SDA_Hold_Time::CONTROLLER_SDA_HOLD_TIME,

--- a/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/main.cc
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/microchip/mcp23008.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -42,7 +43,6 @@ using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::I2C::Address;
 using ::picolibrary::Microchip::MCP23008::Push_Pull_IO_Pin;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -52,6 +52,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::TWI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::TWI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::MCP23008::toggle;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -73,7 +74,7 @@ int main()
 
     toggle<Unbuffered_Output_Stream, Push_Pull_IO_Pin>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     TWI::SDA_Hold_Time::CONTROLLER_SDA_HOLD_TIME,

--- a/test/interactive/picolibrary/microchip/mcp3008/sample/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp3008/sample/main.cc
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/microchip/megaavr0/spi.h"
 #include "picolibrary/spi.h"
 #include "picolibrary/testing/interactive/microchip/mcp3008.h"
@@ -45,7 +46,6 @@ using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
 using ::picolibrary::GPIO::Active_Low_IO_Pin;
 using ::picolibrary::Microchip::MCP3008::Channel;
 using ::picolibrary::Microchip::MCP3008::Channel_Pair;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -58,6 +58,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::SPI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::PORT;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::SPI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::SPI::GPIO_Output_Pin_Device_Selector;
 using ::picolibrary::Testing::Interactive::Microchip::MCP3008::sample;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
@@ -81,7 +82,7 @@ int main()
 
     sample<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Fixed_Configuration_Controller{ CONTROLLER_SPI::instance(),
                                         SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,

--- a/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter_8_n_1/hello_world/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter_8_n_1/hello_world/main.cc
@@ -25,6 +25,7 @@
 #include "picolibrary/microchip/megaavr0/clock.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/asynchronous_serial.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -32,12 +33,12 @@ namespace {
 
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Asynchronous_Serial::hello_world;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -58,7 +59,7 @@ int main()
 
     hello_world( Transmitter_8_N_1{
         TRANSMITTER_USART::instance(),
-        { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+        { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
           .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
 
     for ( ;; ) {}

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/input_pin/state/main.cc
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/gpio.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -37,13 +38,13 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
 using ::picolibrary::Microchip::megaAVR0::GPIO::Input_Pin;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::state;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -63,7 +64,7 @@ int main()
 
     state<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Input_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 1000 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/main.cc
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/gpio.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -37,13 +38,13 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
 using ::picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::state;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -64,7 +65,7 @@ int main()
 
     state<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Internally_Pulled_Up_Input_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 1000 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/open_drain_io_pin/toggle/main.cc
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/gpio.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -37,13 +38,13 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
 using ::picolibrary::Microchip::megaAVR0::GPIO::Open_Drain_IO_Pin;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::toggle;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -63,7 +64,7 @@ int main()
 
     toggle<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Open_Drain_IO_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 500 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/push_pull_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/push_pull_io_pin/toggle/main.cc
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/gpio.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/gpio.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -37,13 +38,13 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
 using ::picolibrary::Microchip::megaAVR0::GPIO::Push_Pull_IO_Pin;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::GPIO::toggle;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -63,7 +64,7 @@ int main()
 
     toggle<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Push_Pull_IO_Pin{ PIN_PORT::instance(), PIN_MASK },
         []() { avrlibcpp::delay_ms( 500 ); } );

--- a/test/interactive/picolibrary/microchip/megaavr0/i2c/controller/scan/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/i2c/controller/scan/main.cc
@@ -27,6 +27,7 @@
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/testing/interactive/i2c.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 
@@ -35,7 +36,6 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -45,6 +45,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::TWI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::TWI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::I2C::scan;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 
@@ -66,7 +67,7 @@ int main()
 
     scan<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_TWI::instance(),
                     TWI::SDA_Hold_Time::CONTROLLER_SDA_HOLD_TIME,

--- a/test/interactive/picolibrary/microchip/megaavr0/spi/controller/spi/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/spi/controller/spi/echo/main.cc
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/microchip/megaavr0/spi.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 #include "picolibrary/testing/interactive/spi.h"
@@ -38,7 +39,6 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -47,6 +47,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::SPI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::SPI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 using ::picolibrary::Testing::Interactive::SPI::echo;
 
@@ -71,7 +72,7 @@ int main()
 
     echo<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Controller{ CONTROLLER_SPI::instance() },
         { .clock_rate     = SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,

--- a/test/interactive/picolibrary/microchip/megaavr0/spi/fixed_configuration_controller/spi/echo/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/spi/fixed_configuration_controller/spi/echo/main.cc
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/microchip/megaavr0/spi.h"
 #include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
 #include "picolibrary/testing/interactive/spi.h"
@@ -38,7 +39,6 @@ namespace {
 using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 
 using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
-using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Clock_Configuration;
 using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
 using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
@@ -47,6 +47,7 @@ using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::SPI_Route;
 using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
 using ::picolibrary::Microchip::megaAVR0::Peripheral::SPI;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
 using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
 using ::picolibrary::Testing::Interactive::SPI::echo;
 
@@ -71,7 +72,7 @@ int main()
 
     echo<Unbuffered_Output_Stream>(
         Transmitter_8_N_1{ TRANSMITTER_USART::instance(),
-                           { .operating_speed = Clock_Configuration::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+                           { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
                              .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } },
         Fixed_Configuration_Controller{ CONTROLLER_SPI::instance(),
                                         SPI::Clock_Rate::CONTROLLER_CLOCK_RATE,


### PR DESCRIPTION
Resolves #293 (Remove asynchronous serial clock configuration operating
speed member type alias).

This member type alias obscured the association with the USART
peripheral which made it more difficult for the reader to understand
what was being configured. This also created an API inconsistency since
other peripheral configuration types are not similarly obscured.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
