### PR TITLE
Use std::uintptr_t for peripheral/register addresses constants

### DIFF
--- a/include/picolibrary/hardware/interrupt_guard.h
+++ b/include/picolibrary/hardware/interrupt_guard.h
@@ -65,7 +65,7 @@ class Interrupt_Guard<Restore_Interrupt_Enable_State> {
     /**
      * \brief CPU peripheral address.
      */
-    static constexpr auto CPU_ADDRESS = std::uint16_t{ 0x0030 };
+    static constexpr auto CPU_ADDRESS = std::uintptr_t{ 0x0030 };
 
     /**
      * \brief CPU peripheral SREG register offset.
@@ -75,7 +75,7 @@ class Interrupt_Guard<Restore_Interrupt_Enable_State> {
     /**
      * \brief CPU peripheral SREG register address.
      */
-    static constexpr auto CPU_SREG_ADDRESS = std::uint16_t{ CPU_ADDRESS + CPU_SREG_OFFSET };
+    static constexpr auto CPU_SREG_ADDRESS = std::uintptr_t{ CPU_ADDRESS + CPU_SREG_OFFSET };
 
     /**
      * \brief The state of the CPU peripheral's SREG register when the interrupt guard

--- a/include/picolibrary/microchip/megaavr0/register.h
+++ b/include/picolibrary/microchip/megaavr0/register.h
@@ -255,7 +255,7 @@ class Protected_Register {
     /**
      * \brief CPU peripheral address.
      */
-    static constexpr auto CPU_ADDRESS = std::uint16_t{ 0x0030 };
+    static constexpr auto CPU_ADDRESS = std::uintptr_t{ 0x0030 };
 
     /**
      * \brief CPU peripheral CCP register offset.
@@ -265,7 +265,7 @@ class Protected_Register {
     /**
      * \brief CPU peripheral CCP register address.
      */
-    static constexpr auto CPU_CCP_ADDRESS = std::uint16_t{ CPU_ADDRESS + CPU_CCP_OFFSET };
+    static constexpr auto CPU_CCP_ADDRESS = std::uintptr_t{ CPU_ADDRESS + CPU_CCP_OFFSET };
 
     /**
      * \brief CPU peripheral CCP register unlock protected I/O registers signature.


### PR DESCRIPTION
Resolves #296 (Use std::uintptr_t for peripheral/register addresses
constants).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
