### PR TITLE
Treat multiplexed signals configuration and lookup errors as fatal errors

### DIFF
--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809/spi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809/spi.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr0/peripheral/atmega4809.h"
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/portmux.h"
@@ -51,9 +52,13 @@ using SPI_Route = Peripheral::PORTMUX::SPI_Route;
  */
 inline void set_spi_route( Peripheral::SPI const & spi, SPI_Route route ) noexcept
 {
-    static_cast<void>( spi );
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            Peripheral::ATmega4809::PORTMUX0::instance().set_spi0_route( route );
+            return;
+    } // switch
 
-    Peripheral::ATmega4809::PORTMUX0::instance().set_spi0_route( route );
+    trap_fatal_error();
 }
 
 /**
@@ -69,16 +74,20 @@ inline void set_spi_route( Peripheral::SPI const & spi, SPI_Route route ) noexce
  */
 inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
-    static_cast<void>( spi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
-        case SPI_Route::DEFAULT: return Peripheral::ATmega4809::PORTA::instance();
-        case SPI_Route::ALTERNATE_1: return Peripheral::ATmega4809::PORTC::instance();
-        case SPI_Route::ALTERNATE_2: return Peripheral::ATmega4809::PORTE::instance();
-        case SPI_Route::NONE: break;
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
+                case SPI_Route::DEFAULT: return Peripheral::ATmega4809::PORTA::instance();
+                case SPI_Route::ALTERNATE_1:
+                    return Peripheral::ATmega4809::PORTC::instance();
+                case SPI_Route::ALTERNATE_2:
+                    return Peripheral::ATmega4809::PORTE::instance();
+                case SPI_Route::NONE: break;
+            } // switch
+            break;
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -94,16 +103,21 @@ inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT
  */
 inline auto spi_vport( Peripheral::SPI const & spi ) noexcept -> Peripheral::VPORT &
 {
-    static_cast<void>( spi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
-        case SPI_Route::DEFAULT: return Peripheral::ATmega4809::VPORTA::instance();
-        case SPI_Route::ALTERNATE_1: return Peripheral::ATmega4809::VPORTC::instance();
-        case SPI_Route::ALTERNATE_2: return Peripheral::ATmega4809::VPORTE::instance();
-        case SPI_Route::NONE: break;
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
+                case SPI_Route::DEFAULT:
+                    return Peripheral::ATmega4809::VPORTA::instance();
+                case SPI_Route::ALTERNATE_1:
+                    return Peripheral::ATmega4809::VPORTC::instance();
+                case SPI_Route::ALTERNATE_2:
+                    return Peripheral::ATmega4809::VPORTE::instance();
+                case SPI_Route::NONE: break;
+            } // switch
+            break;
     } // switch
 
-    return *static_cast<Peripheral::VPORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -151,16 +165,18 @@ inline auto & ds_vport( Peripheral::SPI const & spi ) noexcept
  */
 inline auto ds_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    static_cast<void>( spi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
-        case SPI_Route::DEFAULT: return 7;
-        case SPI_Route::ALTERNATE_1: return 3;
-        case SPI_Route::ALTERNATE_2: return 3;
-        case SPI_Route::NONE: break;
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
+                case SPI_Route::DEFAULT: return 7;
+                case SPI_Route::ALTERNATE_1: return 3;
+                case SPI_Route::ALTERNATE_2: return 3;
+                case SPI_Route::NONE: break;
+            } // switch
+            break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -224,16 +240,18 @@ inline auto & sck_vport( Peripheral::SPI const & spi ) noexcept
  */
 inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    static_cast<void>( spi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
-        case SPI_Route::DEFAULT: return 6;
-        case SPI_Route::ALTERNATE_1: return 2;
-        case SPI_Route::ALTERNATE_2: return 2;
-        case SPI_Route::NONE: break;
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
+                case SPI_Route::DEFAULT: return 6;
+                case SPI_Route::ALTERNATE_1: return 2;
+                case SPI_Route::ALTERNATE_2: return 2;
+                case SPI_Route::NONE: break;
+            } // switch
+            break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -297,16 +315,18 @@ inline auto & codi_vport( Peripheral::SPI const & spi ) noexcept
  */
 inline auto codi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    static_cast<void>( spi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
-        case SPI_Route::DEFAULT: return 4;
-        case SPI_Route::ALTERNATE_1: return 0;
-        case SPI_Route::ALTERNATE_2: return 0;
-        case SPI_Route::NONE: break;
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
+                case SPI_Route::DEFAULT: return 4;
+                case SPI_Route::ALTERNATE_1: return 0;
+                case SPI_Route::ALTERNATE_2: return 0;
+                case SPI_Route::NONE: break;
+            } // switch
+            break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -370,16 +390,18 @@ inline auto & cido_vport( Peripheral::SPI const & spi ) noexcept
  */
 inline auto cido_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
-    static_cast<void>( spi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
-        case SPI_Route::DEFAULT: return 5;
-        case SPI_Route::ALTERNATE_1: return 1;
-        case SPI_Route::ALTERNATE_2: return 1;
-        case SPI_Route::NONE: break;
+    switch ( reinterpret_cast<std::uintptr_t>( &spi ) ) {
+        case Peripheral::ATmega4809::SPI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().spi0_route() ) {
+                case SPI_Route::DEFAULT: return 5;
+                case SPI_Route::ALTERNATE_1: return 1;
+                case SPI_Route::ALTERNATE_2: return 1;
+                case SPI_Route::NONE: break;
+            } // switch
+            break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809/twi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809/twi.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr0/peripheral/atmega4809.h"
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/portmux.h"
@@ -51,9 +52,13 @@ using TWI_Route = Peripheral::PORTMUX::TWI_Route;
  */
 inline void set_twi_route( Peripheral::TWI const & twi, TWI_Route route ) noexcept
 {
-    static_cast<void>( twi );
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            Peripheral::ATmega4809::PORTMUX0::instance().set_twi0_route( route );
+            return;
+    } // switch
 
-    Peripheral::ATmega4809::PORTMUX0::instance().set_twi0_route( route );
+    trap_fatal_error();
 }
 
 /**
@@ -67,11 +72,19 @@ inline void set_twi_route( Peripheral::TWI const & twi, TWI_Route route ) noexce
  *
  * \return The TWI peripheral's SCL pin number.
  */
-constexpr auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
+inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
-    static_cast<void>( twi );
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
+                case TWI_Route::DEFAULT: return 3;
+                case TWI_Route::ALTERNATE_1: return 3;
+                case TWI_Route::ALTERNATE_2: return 3;
+            } // switch
+            break;
+    } // switch
 
-    return 3;
+    trap_fatal_error();
 }
 
 /**
@@ -85,7 +98,7 @@ constexpr auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_f
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-constexpr auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
+inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return 1 << scl_number( twi );
 }
@@ -101,11 +114,19 @@ constexpr auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
  *
  * \return The TWI peripheral's SDA pin number.
  */
-constexpr auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
+inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
-    static_cast<void>( twi );
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
+                case TWI_Route::DEFAULT: return 2;
+                case TWI_Route::ALTERNATE_1: return 2;
+                case TWI_Route::ALTERNATE_2: return 2;
+            } // switch
+            break;
+    } // switch
 
-    return 2;
+    trap_fatal_error();
 }
 
 /**
@@ -119,7 +140,7 @@ constexpr auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_f
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-constexpr auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
+inline auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return 1 << sda_number( twi );
 }
@@ -137,15 +158,19 @@ constexpr auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
  */
 inline auto twi_controller_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
-    static_cast<void>( twi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
-        case TWI_Route::DEFAULT: return Peripheral::ATmega4809::PORTA::instance();
-        case TWI_Route::ALTERNATE_1: return Peripheral::ATmega4809::PORTA::instance();
-        case TWI_Route::ALTERNATE_2: return Peripheral::ATmega4809::PORTC::instance();
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
+                case TWI_Route::DEFAULT: return Peripheral::ATmega4809::PORTA::instance();
+                case TWI_Route::ALTERNATE_1:
+                    return Peripheral::ATmega4809::PORTA::instance();
+                case TWI_Route::ALTERNATE_2:
+                    return Peripheral::ATmega4809::PORTC::instance();
+            } // switch
+            break;
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -162,15 +187,20 @@ inline auto twi_controller_port( Peripheral::TWI const & twi ) noexcept -> Perip
  */
 inline auto twi_controller_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
-    static_cast<void>( twi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
-        case TWI_Route::DEFAULT: return Peripheral::ATmega4809::VPORTA::instance();
-        case TWI_Route::ALTERNATE_1: return Peripheral::ATmega4809::VPORTA::instance();
-        case TWI_Route::ALTERNATE_2: return Peripheral::ATmega4809::VPORTC::instance();
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
+                case TWI_Route::DEFAULT:
+                    return Peripheral::ATmega4809::VPORTA::instance();
+                case TWI_Route::ALTERNATE_1:
+                    return Peripheral::ATmega4809::VPORTA::instance();
+                case TWI_Route::ALTERNATE_2:
+                    return Peripheral::ATmega4809::VPORTC::instance();
+            } // switch
+            break;
     } // switch
 
-    return *static_cast<Peripheral::VPORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -217,7 +247,7 @@ inline auto & controller_scl_vport( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's controller SCL pin number.
  */
-constexpr auto controller_scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto controller_scl_number( Peripheral::TWI const & twi ) noexcept
 {
     return scl_number( twi );
 }
@@ -233,7 +263,7 @@ constexpr auto controller_scl_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's controller SCL pin mask.
  */
-constexpr auto controller_scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto controller_scl_mask( Peripheral::TWI const & twi ) noexcept
 {
     return scl_mask( twi );
 }
@@ -282,7 +312,7 @@ inline auto & controller_sda_vport( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's controller SDA pin number.
  */
-constexpr auto controller_sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto controller_sda_number( Peripheral::TWI const & twi ) noexcept
 {
     return sda_number( twi );
 }
@@ -298,7 +328,7 @@ constexpr auto controller_sda_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's controller SDA pin mask.
  */
-constexpr auto controller_sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto controller_sda_mask( Peripheral::TWI const & twi ) noexcept
 {
     return sda_mask( twi );
 }
@@ -316,15 +346,19 @@ constexpr auto controller_sda_mask( Peripheral::TWI const & twi ) noexcept
  */
 inline auto twi_device_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
-    static_cast<void>( twi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
-        case TWI_Route::DEFAULT: return Peripheral::ATmega4809::PORTC::instance();
-        case TWI_Route::ALTERNATE_1: return Peripheral::ATmega4809::PORTF::instance();
-        case TWI_Route::ALTERNATE_2: return Peripheral::ATmega4809::PORTF::instance();
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
+                case TWI_Route::DEFAULT: return Peripheral::ATmega4809::PORTC::instance();
+                case TWI_Route::ALTERNATE_1:
+                    return Peripheral::ATmega4809::PORTF::instance();
+                case TWI_Route::ALTERNATE_2:
+                    return Peripheral::ATmega4809::PORTF::instance();
+            } // switch
+            break;
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -340,15 +374,20 @@ inline auto twi_device_port( Peripheral::TWI const & twi ) noexcept -> Periphera
  */
 inline auto twi_device_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
-    static_cast<void>( twi );
-
-    switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
-        case TWI_Route::DEFAULT: return Peripheral::ATmega4809::VPORTC::instance();
-        case TWI_Route::ALTERNATE_1: return Peripheral::ATmega4809::VPORTF::instance();
-        case TWI_Route::ALTERNATE_2: return Peripheral::ATmega4809::VPORTF::instance();
+    switch ( reinterpret_cast<std::uintptr_t>( &twi ) ) {
+        case Peripheral::ATmega4809::TWI0::ADDRESS:
+            switch ( Peripheral::ATmega4809::PORTMUX0::instance().twi0_route() ) {
+                case TWI_Route::DEFAULT:
+                    return Peripheral::ATmega4809::VPORTC::instance();
+                case TWI_Route::ALTERNATE_1:
+                    return Peripheral::ATmega4809::VPORTF::instance();
+                case TWI_Route::ALTERNATE_2:
+                    return Peripheral::ATmega4809::VPORTF::instance();
+            } // switch
+            break;
     } // switch
 
-    return *static_cast<Peripheral::VPORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -394,7 +433,7 @@ inline auto & device_scl_vport( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SCL pin number.
  */
-constexpr auto device_scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto device_scl_number( Peripheral::TWI const & twi ) noexcept
 {
     return scl_number( twi );
 }
@@ -410,7 +449,7 @@ constexpr auto device_scl_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SCL pin mask.
  */
-constexpr auto device_scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto device_scl_mask( Peripheral::TWI const & twi ) noexcept
 {
     return scl_mask( twi );
 }
@@ -458,7 +497,7 @@ inline auto & device_sda_vport( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SDA pin number.
  */
-constexpr auto device_sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto device_sda_number( Peripheral::TWI const & twi ) noexcept
 {
     return sda_number( twi );
 }
@@ -474,7 +513,7 @@ constexpr auto device_sda_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SDA pin mask.
  */
-constexpr auto device_sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto device_sda_mask( Peripheral::TWI const & twi ) noexcept
 {
     return sda_mask( twi );
 }

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809/usart.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/atmega4809/usart.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/microchip/megaavr0/peripheral/atmega4809.h"
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/portmux.h"
@@ -54,17 +55,19 @@ inline void set_usart_route( Peripheral::USART const & usart, USART_Route route 
     switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
         case Peripheral::ATmega4809::USART0::ADDRESS:
             Peripheral::ATmega4809::PORTMUX0::instance().set_usart0_route( route );
-            break;
+            return;
         case Peripheral::ATmega4809::USART1::ADDRESS:
             Peripheral::ATmega4809::PORTMUX0::instance().set_usart1_route( route );
-            break;
+            return;
         case Peripheral::ATmega4809::USART2::ADDRESS:
             Peripheral::ATmega4809::PORTMUX0::instance().set_usart2_route( route );
-            break;
+            return;
         case Peripheral::ATmega4809::USART3::ADDRESS:
             Peripheral::ATmega4809::PORTMUX0::instance().set_usart3_route( route );
-            break;
+            return;
     } // switch
+
+    trap_fatal_error();
 }
 
 /**
@@ -91,7 +94,7 @@ inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral
             return Peripheral::ATmega4809::PORTB::instance();
     } // switch
 
-    return *static_cast<Peripheral::PORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -118,7 +121,7 @@ inline auto usart_vport( Peripheral::USART const & usart ) noexcept -> Periphera
             return Peripheral::ATmega4809::VPORTB::instance();
     } // switch
 
-    return *static_cast<Peripheral::VPORT *>( nullptr );
+    trap_fatal_error();
 }
 
 /**
@@ -173,33 +176,33 @@ inline auto xck_number( Peripheral::USART const & usart ) noexcept -> std::uint_
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart0_route() ) {
                 case USART_Route::DEFAULT: return 2;
                 case USART_Route::ALTERNATE: return 6;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART1::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart1_route() ) {
                 case USART_Route::DEFAULT: return 2;
                 case USART_Route::ALTERNATE: return 6;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART2::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart2_route() ) {
                 case USART_Route::DEFAULT: return 2;
                 case USART_Route::ALTERNATE: return 6;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART3::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart3_route() ) {
                 case USART_Route::DEFAULT: return 2;
                 case USART_Route::ALTERNATE: return 2;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -270,33 +273,33 @@ inline auto xdir_number( Peripheral::USART const & usart ) noexcept -> std::uint
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart0_route() ) {
                 case USART_Route::DEFAULT: return 3;
                 case USART_Route::ALTERNATE: return 7;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART1::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart1_route() ) {
                 case USART_Route::DEFAULT: return 3;
                 case USART_Route::ALTERNATE: return 7;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART2::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart2_route() ) {
                 case USART_Route::DEFAULT: return 3;
                 case USART_Route::ALTERNATE: return 3;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART3::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart3_route() ) {
                 case USART_Route::DEFAULT: return 3;
                 case USART_Route::ALTERNATE: return 3;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -367,33 +370,33 @@ inline auto txd_number( Peripheral::USART const & usart ) noexcept -> std::uint_
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart0_route() ) {
                 case USART_Route::DEFAULT: return 0;
                 case USART_Route::ALTERNATE: return 4;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART1::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart1_route() ) {
                 case USART_Route::DEFAULT: return 0;
                 case USART_Route::ALTERNATE: return 4;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART2::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart2_route() ) {
                 case USART_Route::DEFAULT: return 0;
                 case USART_Route::ALTERNATE: return 4;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART3::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart3_route() ) {
                 case USART_Route::DEFAULT: return 0;
                 case USART_Route::ALTERNATE: return 4;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**
@@ -464,33 +467,33 @@ inline auto rxd_number( Peripheral::USART const & usart ) noexcept -> std::uint_
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart0_route() ) {
                 case USART_Route::DEFAULT: return 1;
                 case USART_Route::ALTERNATE: return 5;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART1::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart1_route() ) {
                 case USART_Route::DEFAULT: return 1;
                 case USART_Route::ALTERNATE: return 5;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART2::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart2_route() ) {
                 case USART_Route::DEFAULT: return 1;
                 case USART_Route::ALTERNATE: return 5;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
         case Peripheral::ATmega4809::USART3::ADDRESS:
             switch ( Peripheral::ATmega4809::PORTMUX0::instance().usart3_route() ) {
                 case USART_Route::DEFAULT: return 1;
                 case USART_Route::ALTERNATE: return 5;
-                default: break;
+                case USART_Route::NONE: break;
             } // switch
             break;
     } // switch
 
-    return 0;
+    trap_fatal_error();
 }
 
 /**


### PR DESCRIPTION
Resolves #302 (Treat multiplexed signals configuration and lookup errors
as fatal errors).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
