### PR TITLE
Explicitly delete SYSCFG peripheral special member functions

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/syscfg.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/syscfg.h
@@ -49,6 +49,18 @@ class SYSCFG {
      */
     Register<std::uint8_t> revid;
 
+    SYSCFG() = delete;
+
+    SYSCFG( SYSCFG && ) = delete;
+
+    SYSCFG( SYSCFG const & ) = delete;
+
+    ~SYSCFG() = delete;
+
+    auto operator=( SYSCFG && ) = delete;
+
+    auto operator=( SYSCFG const & ) = delete;
+
     /**
      * \brief Get the device revision.
      *


### PR DESCRIPTION
Resolves #308 (Explicitly delete SYSCFG peripheral special member
functions).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
