### PR TITLE
Remove undefine of SYSCFG macro

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/syscfg.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/syscfg.h
@@ -30,10 +30,6 @@
 
 namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
-#ifdef SYSCFG
-#undef SYSCFG
-#endif // SYSCFG
-
 /**
  * \brief Microchip megaAVR 0-series System Configuration (SYSCFG) peripheral.
  */


### PR DESCRIPTION
Resolves #309 (Remove undefine of SYSCFG macro).

This is now handled by avr-libcpp.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
