### PR TITLE
Add Microchip megaAVR 0-series device info print interactive test

### DIFF
--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
@@ -68,6 +68,7 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp3008/sample/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter_8_n_1/hello_world/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
@@ -1,0 +1,36 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr0 ATmega4809 Arduino Nano Every
+#       picolibrary::Microchip::megaAVR0::Device_Info print interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST                                      ON          CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_VALUE                       "_2"        CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_CONFIGURATION               "DISABLED"  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART                           "USART3"    CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART_ROUTE                     "ALTERNATE" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED "NORMAL"    CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR  "556"       CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_VALUE
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_CONFIGURATION
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART_ROUTE
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR
+)

--- a/test/interactive/picolibrary/microchip/megaavr0/device_info/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/device_info/CMakeLists.txt
@@ -16,3 +16,6 @@
 # File: test/interactive/picolibrary/microchip/megaavr0/device_info/CMakeLists.txt
 # Description: picolibrary::Microchip::megaAVR0::Device_Info interactive tests CMake
 #       rules.
+
+# build the picolibrary::Microchip::megaAVR0::Device_Info print interactive test
+add_subdirectory( print )

--- a/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
@@ -1,0 +1,89 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR0::Device_Info print interactive test CMake
+#       rules.
+
+# build the picolibrary::Microchip::megaAVR0::Device_Info hello world interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr0: enable the picolibrary::Microchip::megaAVR0::Device_Info print interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_VALUE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::Device_Info print interactive test clock prescaler value"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_CONFIGURATION
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::Device_Info print interactive test clock prescaler configuration"
+        )
+
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::Device_Info print interactive test transmitter USART"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART_ROUTE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::Device_Info print interactive test transmitter USART route"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::Device_Info print interactive test transmitter clock generator operating speed"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::Device_Info print interactive test transmitter clock generator scaling factor"
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            PRIVATE CLOCK_PRESCALER_VALUE=${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_VALUE}
+            PRIVATE CLOCK_PRESCALER_CONFIGURATION=${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_CLOCK_PRESCALER_CONFIGURATION}
+            PRIVATE TRANSMITTER_USART=${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART}
+            PRIVATE TRANSMITTER_USART_ROUTE=${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_USART_ROUTE}
+            PRIVATE TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED=${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED}
+            PRIVATE TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR=${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_PRINT_INTERACTIVE_TEST_TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            picolibrary-fatal_error
+            picolibrary-microchip-megaavr0
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PORT}"
+            PROGRAM_FLASH      ${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PROGRAM_FLASH}
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       ${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERIFY_FLASH}
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/megaavr0/device_info/print/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/device_info/print/main.cc
@@ -1,0 +1,66 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Device_Info print interactive test program.
+ */
+
+#include "picolibrary/asynchronous_serial/stream.h"
+#include "picolibrary/microchip/megaavr0/asynchronous_serial.h"
+#include "picolibrary/microchip/megaavr0/clock.h"
+#include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
+#include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/device_info.h"
+
+namespace {
+
+using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
+
+using ::picolibrary::Asynchronous_Serial::Unbuffered_Output_Stream;
+using ::picolibrary::Microchip::megaAVR0::Asynchronous_Serial::Transmitter_8_N_1;
+using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler;
+using ::picolibrary::Microchip::megaAVR0::Clock::Prescaler_Value;
+using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route;
+using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::USART_Route;
+using ::picolibrary::Microchip::megaAVR0::Peripheral::USART;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info::print;
+
+} // namespace
+
+/**
+ * \brief Execute the picolibrary::Microchip::megaAVR0::Device_Info print interactive
+ *        test.
+ *
+ * \return 0.
+ */
+int main()
+{
+    configure_clock( Prescaler_Value::CLOCK_PRESCALER_VALUE, Prescaler::CLOCK_PRESCALER_CONFIGURATION );
+
+    set_usart_route( TRANSMITTER_USART::instance(), USART_Route::TRANSMITTER_USART_ROUTE );
+
+    print<Unbuffered_Output_Stream>( Transmitter_8_N_1{
+        TRANSMITTER_USART::instance(),
+        { .operating_speed = USART::Operating_Speed::TRANSMITTER_CLOCK_GENERATOR_OPERATING_SPEED,
+          .scaling_factor = TRANSMITTER_CLOCK_GENERATOR_SCALING_FACTOR } } );
+
+    for ( ;; ) {}
+}


### PR DESCRIPTION
Resolves #332 (Add Microchip megaAVR 0-series device info print
interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
