### PR TITLE
Fix missing WDT peripheral register assignment operators

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/wdt.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/wdt.h
@@ -80,6 +80,8 @@ class WDT {
         auto operator=( CTRLA && ) = delete;
 
         auto operator=( CTRLA const & ) = delete;
+
+        using Protected_Register<std::uint8_t>::operator=;
     };
 
     /**
@@ -129,6 +131,8 @@ class WDT {
         auto operator=( STATUS && ) = delete;
 
         auto operator=( STATUS const & ) = delete;
+
+        using Protected_Register<std::uint8_t>::operator=;
     };
 
     /**


### PR DESCRIPTION
Resolves #352 (Fix missing WDT peripheral register assignment
operators).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
