### PR TITLE
Fix missing USART multiplexed signals configuration and lookup header include

### DIFF
--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals.h
@@ -23,6 +23,8 @@
 #ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_H
 #define PICOLIBRARY_MICROCHIP_MEGAAVR0_MULTIPLEXED_SIGNALS_H
 
+#include "picolibrary/microchip/megaavr0/multiplexed_signals/usart.h"
+
 /**
  * \brief Microchip megaAVR 0-series multiplexed signals facilities.
  */


### PR DESCRIPTION
Resolves #445 (Fix missing USART multiplexed signals configuration and
lookup header include).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
