### PR TITLE
Fix erroneous multiplexed signals configuration and lookup function compilation errors

### DIFF
--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
@@ -80,6 +80,8 @@ inline auto usart_route( Peripheral::USART const & usart ) noexcept -> USART_Rou
     }  // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return USART_Route::NONE; // unreachable
 }
 
 /**
@@ -144,6 +146,8 @@ constexpr auto usart_port_address( std::uintptr_t usart_address ) noexcept -> st
     };
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -180,6 +184,8 @@ constexpr auto usart_vport_address( std::uintptr_t usart_address ) noexcept -> s
     };
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -285,6 +291,8 @@ constexpr auto xck_number( std::uintptr_t usart_address, USART_Route route ) noe
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -441,6 +449,8 @@ constexpr auto xdir_number( std::uintptr_t usart_address, USART_Route route ) no
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -597,6 +607,8 @@ constexpr auto txd_number( std::uintptr_t usart_address, USART_Route route ) noe
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**
@@ -753,6 +765,8 @@ constexpr auto rxd_number( std::uintptr_t usart_address, USART_Route route ) noe
     } // switch
 
     expect( false, Generic_Error::INVALID_ARGUMENT );
+
+    return 0; // unreachable
 }
 
 /**


### PR DESCRIPTION
Resolves #465 (Fix erroneous multiplexed signals configuration and
lookup function compilation errors).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
