### PR TITLE
Add GPIO internally pulled-up input pin state interactive test

### DIFF
--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
@@ -76,3 +76,4 @@ mark_as_advanced(
 
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt
@@ -1,0 +1,28 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr0 ATmega4809 Arduino Nano Every
+#       picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state
+#       interactive test configuration.
+
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_ENABLE_STATE_INTERACTIVE_TEST   ON       CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_PORT "PORTB"  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_MASK "1 << 1" CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_ENABLE_STATE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_PORT
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_MASK
+)

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/CMakeLists.txt
@@ -16,3 +16,7 @@
 # File: test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/CMakeLists.txt
 # Description: picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin
 #       interactive tests CMake rules.
+
+# build the picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state
+# interactive test
+add_subdirectory( state )

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt
@@ -1,0 +1,66 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt
+# Description: picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin
+#       state interactive test CMake rules.
+
+# build the picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state
+# interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_ENABLE_STATE_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr0: enable the picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_ENABLE_STATE_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_PORT
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state interactive test pin PORT"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_MASK
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state interactive test pin mask"
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-megaavr0-gpio-internally_pulled_up_input_pin-port-state
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-megaavr0-gpio-internally_pulled_up_input_pin-port-state
+            PRIVATE PIN_PORT=${PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_PORT}
+            PRIVATE PIN_MASK=${PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_PIN_MASK}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-megaavr0-gpio-internally_pulled_up_input_pin-port-state
+            picolibrary
+            picolibrary-microchip-megaavr0
+            picolibrary-microchip-megaavr0-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-megaavr0-gpio-internally_pulled_up_input_pin-port-state
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_GPIO_INTERNALLY_PULLED_UP_INPUT_PIN_ENABLE_STATE_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/main.cc
@@ -1,0 +1,61 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state
+ *        interactive test program.
+ */
+
+#include <avr-libcpp/delay>
+
+#include "picolibrary/microchip/megaavr0/gpio.h"
+#include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/testing/interactive/gpio.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/log.h"
+
+namespace {
+
+using ::picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin;
+using ::picolibrary::Testing::Interactive::GPIO::state;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log;
+
+using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
+
+} // namespace
+
+/**
+ * \brief Execute the
+ *        picolibrary::Microchip::megaAVR0::GPIO::Internally_Pulled_Up_Input_Pin state
+ *        interactive test.
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    configure_clock();
+
+    Log::initialize();
+
+    state( Log::instance(), Internally_Pulled_Up_Input_Pin{ PIN_PORT::instance(), PIN_MASK }, []() {
+        avrlibcpp::delay_ms( 1000 );
+    } );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #473 (Add GPIO internally pulled-up input pin state interactive
test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
