### PR TITLE
Add Microchip megaAVR 0-series asynchronous serial USART data bits configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -23,10 +23,26 @@
 #ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_ASYNCHRONOUS_SERIAL_H
 #define PICOLIBRARY_MICROCHIP_MEGAAVR0_ASYNCHRONOUS_SERIAL_H
 
+#include <cstdint>
+
+#include "picolibrary/microchip/megaavr0/peripheral/usart.h"
+
 /**
  * \brief Microchip megaAVR 0-series asynchronous serial facilities.
  */
 namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial {
+
+/**
+ * \brief USART data bits configuration.
+ */
+enum class USART_Data_Bits : std::uint8_t {
+    _5 = Peripheral::USART::CTRLC::CHSIZE_5BIT,  ///< 5.
+    _6 = Peripheral::USART::CTRLC::CHSIZE_6BIT,  ///< 6.
+    _7 = Peripheral::USART::CTRLC::CHSIZE_7BIT,  ///< 7.
+    _8 = Peripheral::USART::CTRLC::CHSIZE_8BIT,  ///< 8.
+    _9 = Peripheral::USART::CTRLC::CHSIZE_9BITH, ///< 9.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_ASYNCHRONOUS_SERIAL_H


### PR DESCRIPTION
Resolves #497 (Add Microchip megaAVR 0-series asynchronous serial USART
data bits configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
