### PR TITLE
Add Microchip megaAVR 0-series asynchronous serial USART parity configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -43,6 +43,15 @@ enum class USART_Data_Bits : std::uint8_t {
     _9 = Peripheral::USART::CTRLC::CHSIZE_9BITH, ///< 9.
 };
 
+/**
+ * \brief USART parity configuration.
+ */
+enum class USART_Parity : std::uint8_t {
+    NONE = Peripheral::USART::CTRLC::PMODE_DISABLED, ///< None.
+    EVEN = Peripheral::USART::CTRLC::PMODE_EVEN,     ///< Even.
+    ODD  = Peripheral::USART::CTRLC::PMODE_ODD,      ///< Odd.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_ASYNCHRONOUS_SERIAL_H


### PR DESCRIPTION
Resolves #498 (Add Microchip megaAVR 0-series asynchronous serial USART
parity configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
