### PR TITLE
Add Microchip megaAVR 0-series asynchronous serial USART stop bits configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -52,6 +52,14 @@ enum class USART_Parity : std::uint8_t {
     ODD  = Peripheral::USART::CTRLC::PMODE_ODD,      ///< Odd.
 };
 
+/**
+ * \brief USART stop bits configuration.
+ */
+enum class USART_Stop_Bits : std::uint8_t {
+    _1 = 0b0 << Peripheral::USART::CTRLC::Bit::SBMODE, ///< 1.
+    _2 = 0b1 << Peripheral::USART::CTRLC::Bit::SBMODE, ///< 2.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_ASYNCHRONOUS_SERIAL_H


### PR DESCRIPTION
Resolves #499 (Add Microchip megaAVR 0-series asynchronous serial USART
stop bits configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
