### PR TITLE
Add Microchip megaAVR 0-series asynchronous serial USART clock generator operating speed configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -60,6 +60,14 @@ enum class USART_Stop_Bits : std::uint8_t {
     _2 = 0b1 << Peripheral::USART::CTRLC::Bit::SBMODE, ///< 2.
 };
 
+/**
+ * \brief USART clock generator operating speed configuration.
+ */
+enum class USART_Clock_Generator_Operating_Speed : std::uint8_t {
+    NORMAL = Peripheral::USART::CTRLB::RXMODE_NORMAL, ///< Normal.
+    DOUBLE = Peripheral::USART::CTRLB::RXMODE_CLK2X,  ///< Double.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::Asynchronous_Serial
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_ASYNCHRONOUS_SERIAL_H


### PR DESCRIPTION
Resolves #500 (Add Microchip megaAVR 0-series asynchronous serial USART
clock generator operating speed configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
