### PR TITLE
Add Microchip megaAVR 0-series I2C TWI bus speed

### DIFF
--- a/include/picolibrary/microchip/megaavr0/i2c.h
+++ b/include/picolibrary/microchip/megaavr0/i2c.h
@@ -42,6 +42,15 @@ enum class TWI_SDA_Hold_Time : std::uint8_t {
     _500_NS = Peripheral::TWI::CTRLA::SDAHOLD_500NS, ///< 500 ns (meets the SMBus 2.0 specifications across all corners).
 };
 
+/**
+ * \brief TWI bus speed configuration.
+ */
+enum class TWI_Bus_Speed : std::uint8_t {
+    STANDARD  = 0b0 << Peripheral::TWI::CTRLA::Bit::FMPEN, ///< Standard mode.
+    FAST      = 0b0 << Peripheral::TWI::CTRLA::Bit::FMPEN, ///< Fast mode.
+    FAST_PLUS = 0b1 << Peripheral::TWI::CTRLA::Bit::FMPEN, ///< Fast mode plus.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::I2C
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_I2C_H


### PR DESCRIPTION
Resolves #531 (Add Microchip megaAVR 0-series I2C TWI bus speed).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
