### PR TITLE
Add Microchip megaAVR 0-series I2C controller

### DIFF
--- a/include/picolibrary/microchip/megaavr0/i2c.h
+++ b/include/picolibrary/microchip/megaavr0/i2c.h
@@ -430,6 +430,11 @@ class Basic_Controller {
     }
 };
 
+/**
+ * \brief Controller.
+ */
+using Controller = ::picolibrary::I2C::Controller<Basic_Controller>;
+
 } // namespace picolibrary::Microchip::megaAVR0::I2C
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_I2C_H


### PR DESCRIPTION
Resolves #534 (Add Microchip megaAVR 0-series I2C controller).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
