### PR TITLE
Fix Microchip megaAVR 0-series basic controller stop condition transmission

### DIFF
--- a/include/picolibrary/microchip/megaavr0/i2c.h
+++ b/include/picolibrary/microchip/megaavr0/i2c.h
@@ -326,7 +326,7 @@ class Basic_Controller {
      */
     void transmit_stop() noexcept
     {
-        m_twi->mctrlb = Peripheral::TWI::MCTRLB::MCMD_STOP;
+        m_twi->mctrlb |= Peripheral::TWI::MCTRLB::MCMD_STOP;
     }
 
     /**


### PR DESCRIPTION
Resolves #557 (Fix Microchip megaAVR 0-series basic controller stop
condition transmission).

The previous implementation failed to preserve the TWI.MCTRLB register's
ACKACT field when issuing the STOP command which prevented proper read
termination.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
