### PR TITLE
Add Microchip megaAVR 0-series SPI SPI clock polarity

### DIFF
--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -52,6 +52,14 @@ enum class SPI_Clock_Rate : std::uint8_t {
                   | Peripheral::SPI::CTRLA::PRESC_DIV128, ///< Peripheral clock frequency / 128.
 };
 
+/**
+ * \brief SPI clock polarity.
+ */
+enum class SPI_Clock_Polarity : std::uint8_t {
+    IDLE_LOW  = 0b00 << Peripheral::SPI::CTRLB::Bit::MODE, ///< Idle low.
+    IDLE_HIGH = 0b10 << Peripheral::SPI::CTRLB::Bit::MODE, ///< Idle high.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::SPI
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_SPI_H


### PR DESCRIPTION
Resolves #569 (Add Microchip megaAVR 0-series SPI SPI clock polarity).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
