### PR TITLE
Add Microchip megaAVR 0-series SPI USART clock polarity

### DIFF
--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 
+#include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
 
 /**
@@ -74,6 +75,14 @@ enum class SPI_Clock_Phase : std::uint8_t {
 enum class SPI_Bit_Order : std::uint8_t {
     MSB_FIRST = 0b0 << Peripheral::SPI::CTRLA::Bit::DORD, ///< MSB first.
     LSB_FIRST = 0b1 << Peripheral::SPI::CTRLA::Bit::DORD, ///< LSB first.
+};
+
+/**
+ * \brief USART clock polarity.
+ */
+enum class USART_Clock_Polarity : std::uint8_t {
+    IDLE_LOW  = 0b0 << Peripheral::PORT::PINCTRL::Bit::INVEN, ///< Idle low.
+    IDLE_HIGH = 0b1 << Peripheral::PORT::PINCTRL::Bit::INVEN, ///< Idle high.
 };
 
 } // namespace picolibrary::Microchip::megaAVR0::SPI


### PR DESCRIPTION
Resolves #572 (Add Microchip megaAVR 0-series SPI USART clock polarity).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
