### PR TITLE
Add Microchip megaAVR 0-series SPI USART bit order

### DIFF
--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -94,6 +94,14 @@ enum class USART_Clock_Phase : std::uint8_t {
     CAPTURE_ACTIVE_TO_IDLE = 0b1 << Peripheral::USART::CTRLC::Bit::UCPHA, ///< Capture data on the active-to-idle clock transition.
 };
 
+/**
+ * \brief USART bit order.
+ */
+enum class USART_Bit_Order : std::uint8_t {
+    MSB_FIRST = 0b0 << Peripheral::USART::CTRLC::Bit::UDORD, ///< MSB first.
+    LSB_FIRST = 0b1 << Peripheral::USART::CTRLC::Bit::UDORD, ///< LSB first.
+};
+
 } // namespace picolibrary::Microchip::megaAVR0::SPI
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_SPI_H


### PR DESCRIPTION
Resolves #574 (Add Microchip megaAVR 0-series SPI USART bit order).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
