### PR TITLE
Add Microchip megaAVR 0-series fixed configuration SPI basic controller

### DIFF
--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -102,6 +102,15 @@ enum class USART_Bit_Order : std::uint8_t {
     LSB_FIRST = 0b1 << Peripheral::USART::CTRLC::Bit::UDORD, ///< LSB first.
 };
 
+/**
+ * \brief Fixed configuration basic controller.
+ *
+ * \tparam Peripheral The type of peripheral used to implement fixed configuration
+ *         controller functionality.
+ */
+template<typename Peripheral>
+class Fixed_Configuration_Basic_Controller;
+
 } // namespace picolibrary::Microchip::megaAVR0::SPI
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_SPI_H


### PR DESCRIPTION
Resolves #577 (Add Microchip megaAVR 0-series fixed configuration SPI
basic controller).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
