### PR TITLE
Add Microchip megaAVR 0-series fixed configuration SPI controller

### DIFF
--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -28,6 +28,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
 #include "picolibrary/microchip/megaavr0/peripheral/usart.h"
+#include "picolibrary/spi.h"
 
 /**
  * \brief Microchip megaAVR 0-series Serial Peripheral Interface (SPI) facilities.
@@ -110,6 +111,16 @@ enum class USART_Bit_Order : std::uint8_t {
  */
 template<typename Peripheral>
 class Fixed_Configuration_Basic_Controller;
+
+/**
+ * \brief Fixed configuration controller.
+ *
+ * \tparam Peripheral The type of peripheral used to implement fixed configuration
+ *         controller functionality.
+ */
+template<typename Peripheral>
+using Fixed_Configuration_Controller =
+    ::picolibrary::SPI::Controller<Fixed_Configuration_Basic_Controller<Peripheral>>;
 
 } // namespace picolibrary::Microchip::megaAVR0::SPI
 


### PR DESCRIPTION
Resolves #578 (Add Microchip megaAVR 0-series fixed configuration SPI
controller).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
