### PR TITLE
Fix USART peripheral CTRLC register CMODE field enumerator name mismatch

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/usart.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/usart.h
@@ -463,7 +463,7 @@ class USART {
             CMODE_ASYNCHRONOUS = 0x0 << Bit::CMODE, ///< Asynchronous USART.
             CMODE_SYNCHRONOUS  = 0x1 << Bit::CMODE, ///< Synchronous USART.
             CMODE_IRCOM        = 0x2 << Bit::CMODE, ///< Infrared communication.
-            CMODE_HSPI         = 0x3 << Bit::CMODE, ///< Host SPI.
+            CMODE_MSPI         = 0x3 << Bit::CMODE, ///< Host SPI.
         };
 
         CTRLC() = delete;


### PR DESCRIPTION
Resolves #599 (Fix USART peripheral CTRLC register CMODE field
enumerator name mismatch).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
