### PR TITLE
Add Microchip megaAVR 0-series variable configuration SPI controller

### DIFF
--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -672,6 +672,16 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
 template<typename Peripheral>
 class Variable_Configuration_Basic_Controller;
 
+/**
+ * \brief Variable configuration controller.
+ *
+ * \tparam Peripheral The type of peripheral used to implement variable configuration
+ *         controller functionality.
+ */
+template<typename Peripheral>
+using Variable_Configuration_Controller =
+    ::picolibrary::SPI::Controller<Variable_Configuration_Basic_Controller<Peripheral>>;
+
 } // namespace picolibrary::Microchip::megaAVR0::SPI
 
 #endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_SPI_H


### PR DESCRIPTION
Resolves #605 (Add Microchip megaAVR 0-series variable configuration SPI
controller).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
