### PR TITLE
Add Microchip MCP23008 open-drain I/O pin toggle interactive test

### DIFF
--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
@@ -79,6 +79,7 @@ mark_as_advanced(
 # configure interactive tests
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/asynchronous_serial/unbuffered_output_stream/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,36 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary-microchip-megaavr0 ATmega4809 Arduino Nano Every
+#       picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+#       configuration.
+
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST                                        ON          CACHE BOOL   "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI                                "TWI0"      CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_SDA_HOLD_TIME                  "OFF"       CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BUS_SPEED                      "FAST_PLUS" CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_CLOCK_GENERATOR_SCALING_FACTOR "2"         CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_INACTIVE_BUS_TIME_OUT          "DISABLED"  CACHE STRING "" FORCE )
+set( PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_ROUTE                          "DEFAULT"   CACHE STRING "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_SDA_HOLD_TIME
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BUS_SPEED
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_CLOCK_GENERATOR_SCALING_FACTOR
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_INACTIVE_BUS_TIME_OUT
+    PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_ROUTE
+)

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/CMakeLists.txt
@@ -16,3 +16,6 @@
 # File: test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/CMakeLists.txt
 # Description: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin interactive tests CMake
 #       rules.
+
+# build the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+add_subdirectory( toggle )

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -1,0 +1,106 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+# Description: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+#       CMake rules.
+
+# build the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr0: enable the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_SDA_HOLD_TIME
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI SDA hold time"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BUS_SPEED
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI bus speed"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_CLOCK_GENERATOR_SCALING_FACTOR
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI clock generator scaling factor"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_INACTIVE_BUS_TIME_OUT
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI inactive bus time-out"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_ROUTE
+            "" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test controller TWI route"
+        )
+
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS
+            "Address_Numeric{ 0b0100'000 }" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test MCP23008 address"
+        )
+        set(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK
+            "1 << 0" CACHE STRING
+            "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test MCP23008 pin mask"
+        )
+        mark_as_advanced(
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS
+            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK
+        )
+
+        add_executable(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            main.cc
+        )
+        target_compile_definitions(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            PRIVATE CONTROLLER_TWI=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI}
+            PRIVATE CONTROLLER_TWI_SDA_HOLD_TIME=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_SDA_HOLD_TIME}
+            PRIVATE CONTROLLER_TWI_BUS_SPEED=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_BUS_SPEED}
+            PRIVATE CONTROLLER_TWI_CLOCK_GENERATOR_SCALING_FACTOR=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_CLOCK_GENERATOR_SCALING_FACTOR}
+            PRIVATE CONTROLLER_TWI_INACTIVE_BUS_TIME_OUT=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_INACTIVE_BUS_TIME_OUT}
+            PRIVATE CONTROLLER_TWI_ROUTE=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_CONTROLLER_TWI_ROUTE}
+            PRIVATE MCP23008_ADDRESS=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS}
+            PRIVATE MCP23008_PIN_MASK=${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK}
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            picolibrary
+            picolibrary-microchip-megaavr0
+            picolibrary-microchip-megaavr0-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_ENABLE_TOGGLE_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
@@ -17,8 +17,8 @@
 
 /**
  * \file
- * \brief picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle
- *        interactive test program.
+ * \brief picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test
+ *        program.
  */
 
 #include <avr-libcpp/delay>
@@ -51,8 +51,8 @@ using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
 } // namespace
 
 /**
- * \brief Execute the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin
- *        toggle interactive test.
+ * \brief Execute the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle
+ *        interactive test.
  *
  * \return N/A
  */

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/main.cc
@@ -1,0 +1,78 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle
+ *        interactive test program.
+ */
+
+#include <avr-libcpp/delay>
+
+#include "picolibrary/microchip/mcp23008.h"
+#include "picolibrary/microchip/megaavr0/i2c.h"
+#include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
+#include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/testing/interactive/microchip/mcp23008.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/log.h"
+
+namespace {
+
+using ::picolibrary::Microchip::MCP23008::Address_Numeric;
+using ::picolibrary::Microchip::MCP23008::Address_Transmitted;
+using ::picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin;
+using ::picolibrary::Microchip::megaAVR0::I2C::Controller;
+using ::picolibrary::Microchip::megaAVR0::I2C::TWI_Bus_Speed;
+using ::picolibrary::Microchip::megaAVR0::I2C::TWI_Inactive_Bus_Time_Out;
+using ::picolibrary::Microchip::megaAVR0::I2C::TWI_SDA_Hold_Time;
+using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_twi_route;
+using ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::TWI_Route;
+using ::picolibrary::Testing::Interactive::Microchip::MCP23008::toggle;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log;
+
+using namespace ::picolibrary::Microchip::megaAVR0::Peripheral;
+
+} // namespace
+
+/**
+ * \brief Execute the picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin
+ *        toggle interactive test.
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    configure_clock();
+
+    Log::initialize();
+
+    set_twi_route( CONTROLLER_TWI::instance(), TWI_Route::CONTROLLER_TWI_ROUTE );
+
+    toggle<Open_Drain_IO_Pin>(
+        Controller{ CONTROLLER_TWI::instance(),
+                    TWI_SDA_Hold_Time::CONTROLLER_TWI_SDA_HOLD_TIME,
+                    TWI_Bus_Speed::CONTROLLER_TWI_BUS_SPEED,
+                    CONTROLLER_TWI_CLOCK_GENERATOR_SCALING_FACTOR,
+                    TWI_Inactive_Bus_Time_Out::CONTROLLER_TWI_INACTIVE_BUS_TIME_OUT },
+        MCP23008_ADDRESS,
+        MCP23008_PIN_MASK,
+        []() { avrlibcpp::delay_ms( 500 ); } );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #629 (Add Microchip MCP23008 open-drain I/O pin toggle
interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
