### PR TITLE
Add Microchip MCP23S08 internally pulled-up input pin interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/CMakeLists.txt
@@ -13,9 +13,6 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/interactive/picolibrary/microchip/mcp23s08/CMakeLists.txt
-# Description: picolibrary::Microchip::MCP23S08 interactive tests CMake rules.
-
-# build the picolibrary::Microchip::MCP23S08::Internally_Pulled_Up_Input_Pin interactive
-# tests
-add_subdirectory( internally_pulled_up_input_pin )
+# File: test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/CMakeLists.txt
+# Description: picolibrary::Microchip::MCP23S08::Internally_Pulled_Up_Input_Pin
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #637 (Add Microchip MCP23S08 internally pulled-up input pin
interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
