### PR TITLE
Add Microchip megaAVR 0-series interrupt facilities namespace

### DIFF
--- a/include/picolibrary/microchip/megaavr0/interrupt.h
+++ b/include/picolibrary/microchip/megaavr0/interrupt.h
@@ -1,0 +1,32 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Interrupt interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_INTERRUPT_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_INTERRUPT_H
+
+/**
+ * \brief Microchip megaAVR 0-series interrupt facilities.
+ */
+namespace picolibrary::Microchip::megaAVR0::Interrupt {
+} // namespace picolibrary::Microchip::megaAVR0::Interrupt
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_INTERRUPT_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -29,6 +29,7 @@ set(
     "picolibrary/microchip/megaavr0/clock.cc"
     "picolibrary/microchip/megaavr0/gpio.cc"
     "picolibrary/microchip/megaavr0/i2c.cc"
+    "picolibrary/microchip/megaavr0/interrupt.cc"
     "picolibrary/microchip/megaavr0/multiplexed_signals.cc"
     "picolibrary/microchip/megaavr0/multiplexed_signals/spi.cc"
     "picolibrary/microchip/megaavr0/multiplexed_signals/twi.cc"

--- a/source/picolibrary/microchip/megaavr0/interrupt.cc
+++ b/source/picolibrary/microchip/megaavr0/interrupt.cc
@@ -1,0 +1,23 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Interrupt implementation.
+ */
+
+#include "picolibrary/microchip/megaavr0/interrupt.h"


### PR DESCRIPTION
Resolves #651 (Add Microchip megaAVR 0-series interrupt facilities
namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
