### PR TITLE
Replace static casts with enum underlying type conversion utility calls

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -30,6 +30,7 @@
 #include "picolibrary/asynchronous_serial.h"
 #include "picolibrary/microchip/megaavr0/multiplexed_signals.h"
 #include "picolibrary/microchip/megaavr0/peripheral/usart.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR 0-series asynchronous serial facilities.
@@ -217,12 +218,11 @@ class Basic_Transmitter {
         USART_Clock_Generator_Operating_Speed usart_clock_generator_operating_speed,
         std::uint16_t usart_clock_generator_scaling_factor ) noexcept
     {
-        m_usart->ctrlb = static_cast<std::uint8_t>( usart_clock_generator_operating_speed );
+        m_usart->ctrlb = to_underlying( usart_clock_generator_operating_speed );
         m_usart->ctrla = 0;
         m_usart->ctrlc = Peripheral::USART::CTRLC::CMODE_ASYNCHRONOUS
-                         | static_cast<std::uint8_t>( usart_data_bits )
-                         | static_cast<std::uint8_t>( usart_parity )
-                         | static_cast<std::uint8_t>( usart_stop_bits );
+                         | to_underlying( usart_data_bits ) | to_underlying( usart_parity )
+                         | to_underlying( usart_stop_bits );
         m_usart->baud = usart_clock_generator_scaling_factor;
     }
 

--- a/include/picolibrary/microchip/megaavr0/clock.h
+++ b/include/picolibrary/microchip/megaavr0/clock.h
@@ -27,6 +27,7 @@
 
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/clkctrl.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR 0-series clock facilities
@@ -78,7 +79,7 @@ inline void set_source( Source source ) noexcept
     auto & clkctrl = Peripheral::CLKCTRL0::instance();
 
     clkctrl.mclkctrla = ( clkctrl.mclkctrla & ~Peripheral::CLKCTRL::MCLKCTRLA::Mask::CLKSEL )
-                        | static_cast<std::uint8_t>( source );
+                        | to_underlying( source );
 }
 
 /**
@@ -186,7 +187,7 @@ inline void configure_prescaler( Prescaler_Value value, Prescaler configuration 
 {
     auto & clkctrl = Peripheral::CLKCTRL0::instance();
 
-    clkctrl.mclkctrlb = static_cast<std::uint8_t>( value ) | static_cast<std::uint8_t>( configuration );
+    clkctrl.mclkctrlb = to_underlying( value ) | to_underlying( configuration );
 }
 
 /**
@@ -275,7 +276,7 @@ inline void set_internal_16_20_MHz_oscillator_mode( Internal_16_20_MHz_Oscillato
 {
     auto & clkctrl = Peripheral::CLKCTRL0::instance();
 
-    clkctrl.osc20mctrla = static_cast<std::uint8_t>( mode );
+    clkctrl.osc20mctrla = to_underlying( mode );
 }
 
 /**
@@ -351,7 +352,7 @@ inline void set_internal_32_768_kHz_ultra_low_power_oscillator_mode( Internal_32
 {
     auto & clkctrl = Peripheral::CLKCTRL0::instance();
 
-    clkctrl.osc32kctrla = static_cast<std::uint8_t>( mode );
+    clkctrl.osc32kctrla = to_underlying( mode );
 }
 
 /**
@@ -446,9 +447,8 @@ inline void configure_external_32_768_kHz_crystal_oscillator(
 {
     auto & clkctrl = Peripheral::CLKCTRL0::instance();
 
-    clkctrl.xosc32kctrla = static_cast<std::uint8_t>( source )
-                           | static_cast<std::uint8_t>( start_up_time )
-                           | static_cast<std::uint8_t>( mode );
+    clkctrl.xosc32kctrla = to_underlying( source ) | to_underlying( start_up_time )
+                           | to_underlying( mode );
 }
 
 /**
@@ -461,7 +461,7 @@ inline void set_external_32_768_kHz_crystal_oscillator_mode( External_32_768_kHz
     auto & clkctrl = Peripheral::CLKCTRL0::instance();
 
     clkctrl.xosc32kctrla = ( clkctrl.xosc32kctrla & ~Peripheral::CLKCTRL::XOSC32KCTRLA::Mask::RUNSTDBY )
-                           | static_cast<std::uint8_t>( mode );
+                           | to_underlying( mode );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr0/i2c.h
+++ b/include/picolibrary/microchip/megaavr0/i2c.h
@@ -29,6 +29,7 @@
 #include "picolibrary/i2c.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
 #include "picolibrary/postcondition.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR 0-series Inter-Integrated Circuit (I2C) facilities.
@@ -280,10 +281,9 @@ class Basic_Controller {
         TWI_Inactive_Bus_Time_Out twi_inactive_bus_time_out ) noexcept
     {
         m_twi->mbaud  = twi_clock_generator_scaling_factor;
-        m_twi->mctrla = static_cast<std::uint8_t>( twi_inactive_bus_time_out )
+        m_twi->mctrla = to_underlying( twi_inactive_bus_time_out )
                         | Peripheral::TWI::MCTRLA::Mask::SMEN;
-        m_twi->ctrla = static_cast<std::uint8_t>( twi_sda_hold_time )
-                       | static_cast<std::uint8_t>( twi_bus_speed );
+        m_twi->ctrla = to_underlying( twi_sda_hold_time ) | to_underlying( twi_bus_speed );
     }
 
     /**
@@ -360,7 +360,7 @@ class Basic_Controller {
      */
     void initiate_addressing( ::picolibrary::I2C::Address_Transmitted address, ::picolibrary::I2C::Operation operation ) noexcept
     {
-        m_twi->maddr = address.as_unsigned_integer() | static_cast<std::uint8_t>( operation );
+        m_twi->maddr = address.as_unsigned_integer() | to_underlying( operation );
     }
 
     /**

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/spi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/spi.h
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
 #include "picolibrary/microchip/megaavr0/peripheral/vport.h"
 #include "picolibrary/precondition.h"
+#include "picolibrary/utility.h"
 
 namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals {
 
@@ -84,7 +85,7 @@ inline void set_spi_route( Peripheral::SPI const & spi, SPI_Route route ) noexce
         case Peripheral::SPI0::ADDRESS:
             portmux.twispiroutea = ( portmux.twispiroutea
                                      & ~Peripheral::PORTMUX::TWISPIROUTEA::Mask::SPI0 )
-                                   | static_cast<std::uint8_t>( route );
+                                   | to_underlying( route );
             return;
     } // switch
 

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/twi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/twi.h
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
 #include "picolibrary/microchip/megaavr0/peripheral/vport.h"
 #include "picolibrary/precondition.h"
+#include "picolibrary/utility.h"
 
 namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals {
 
@@ -80,7 +81,7 @@ inline void set_twi_route( Peripheral::TWI const & twi, TWI_Route route ) noexce
         case Peripheral::TWI0::ADDRESS:
             portmux.twispiroutea = ( portmux.twispiroutea
                                      & ~Peripheral::PORTMUX::TWISPIROUTEA::Mask::TWI0 )
-                                   | static_cast<std::uint8_t>( route );
+                                   | to_underlying( route );
             return;
     } // switch
 

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/microchip/megaavr0/peripheral/vport.h"
 #include "picolibrary/precondition.h"
+#include "picolibrary/utility.h"
 
 namespace picolibrary::Microchip::megaAVR0::Multiplexed_Signals {
 
@@ -99,24 +100,24 @@ inline void set_usart_route( Peripheral::USART const & usart, USART_Route route 
     switch ( reinterpret_cast<std::uintptr_t>( &usart ) ) {
         case Peripheral::USART0::ADDRESS:
             portmux.usartroutea = ( portmux.usartroutea & ~Peripheral::PORTMUX::USARTROUTEA::Mask::USART0 )
-                                  | ( static_cast<std::uint8_t>( route )
+                                  | ( to_underlying( route )
                                       << Peripheral::PORTMUX::USARTROUTEA::Bit::USART0 );
             return;
         case Peripheral::USART1::ADDRESS:
             portmux.usartroutea = ( portmux.usartroutea & ~Peripheral::PORTMUX::USARTROUTEA::Mask::USART1 )
-                                  | ( static_cast<std::uint8_t>( route )
+                                  | ( to_underlying( route )
                                       << Peripheral::PORTMUX::USARTROUTEA::Bit::USART1 );
             return;
         case Peripheral::USART2::ADDRESS:
             portmux.usartroutea = ( portmux.usartroutea & ~Peripheral::PORTMUX::USARTROUTEA::Mask::USART2 )
-                                  | ( static_cast<std::uint8_t>( route )
+                                  | ( to_underlying( route )
                                       << Peripheral::PORTMUX::USARTROUTEA::Bit::USART2 );
             return;
 #if defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) \
     || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
         case Peripheral::USART3::ADDRESS:
             portmux.usartroutea = ( portmux.usartroutea & ~Peripheral::PORTMUX::USARTROUTEA::Mask::USART3 )
-                                  | ( static_cast<std::uint8_t>( route )
+                                  | ( to_underlying( route )
                                       << Peripheral::PORTMUX::USARTROUTEA::Bit::USART3 );
             return;
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )

--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -32,6 +32,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
 #include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/spi.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip megaAVR 0-series Serial Peripheral Interface (SPI) facilities.
@@ -313,11 +314,9 @@ class Fixed_Configuration_Basic_Controller<Peripheral::SPI> {
         SPI_Bit_Order      spi_bit_order ) noexcept
     {
         m_spi->ctrla = Peripheral::SPI::CTRLA::Mask::MASTER
-                       | static_cast<std::uint8_t>( spi_clock_rate )
-                       | static_cast<std::uint8_t>( spi_bit_order );
-        m_spi->ctrlb = Peripheral::SPI::CTRLB::Mask::SSD
-                       | static_cast<std::uint8_t>( spi_clock_polarity )
-                       | static_cast<std::uint8_t>( spi_clock_phase );
+                       | to_underlying( spi_clock_rate ) | to_underlying( spi_bit_order );
+        m_spi->ctrlb = Peripheral::SPI::CTRLB::Mask::SSD | to_underlying( spi_clock_polarity )
+                       | to_underlying( spi_clock_phase );
         m_spi->intctrl = 0;
     }
 
@@ -583,15 +582,14 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
     {
         m_usart->ctrlb = 0;
         m_usart->ctrla = 0;
-        m_usart->ctrlc = Peripheral::USART::CTRLC::CMODE_MSPI
-                         | static_cast<std::uint8_t>( usart_clock_phase )
-                         | static_cast<std::uint8_t>( usart_bit_order );
+        m_usart->ctrlc = Peripheral::USART::CTRLC::CMODE_MSPI | to_underlying( usart_clock_phase )
+                         | to_underlying( usart_bit_order );
         m_usart->baud = usart_clock_generator_scaling_factor;
 
         m_usart_xck_txd_port->pinctrl[ m_usart_xck_number ] =
             ( m_usart_xck_txd_port->pinctrl[ m_usart_xck_number ]
               & ~Peripheral::PORT::PINCTRL::Mask::INVEN )
-            | static_cast<std::uint8_t>( usart_clock_polarity );
+            | to_underlying( usart_clock_polarity );
     }
 
     /**
@@ -720,11 +718,10 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
             SPI_Bit_Order      spi_bit_order ) noexcept :
             m_ctrla{ static_cast<std::uint8_t>(
                 Peripheral::SPI::CTRLA::Mask::MASTER | Peripheral::SPI::CTRLA::Mask::ENABLE
-                | static_cast<std::uint8_t>( spi_clock_rate )
-                | static_cast<std::uint8_t>( spi_bit_order ) ) },
+                | to_underlying( spi_clock_rate ) | to_underlying( spi_bit_order ) ) },
             m_ctrlb{ static_cast<std::uint8_t>(
-                Peripheral::SPI::CTRLB::Mask::SSD | static_cast<std::uint8_t>( spi_clock_polarity )
-                | static_cast<std::uint8_t>( spi_clock_phase ) ) }
+                Peripheral::SPI::CTRLB::Mask::SSD | to_underlying( spi_clock_polarity )
+                | to_underlying( spi_clock_phase ) ) }
         {
         }
 
@@ -1036,10 +1033,10 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
             USART_Clock_Polarity usart_clock_polarity,
             USART_Clock_Phase    usart_clock_phase,
             USART_Bit_Order      usart_bit_order ) noexcept :
-            m_port_pinctrl_inven{ static_cast<std::uint8_t>( usart_clock_polarity ) },
+            m_port_pinctrl_inven{ to_underlying( usart_clock_polarity ) },
             m_usart_ctrlc{ static_cast<std::uint8_t>(
-                Peripheral::USART::CTRLC::CMODE_MSPI | static_cast<std::uint8_t>( usart_clock_phase )
-                | static_cast<std::uint8_t>( usart_bit_order ) ) },
+                Peripheral::USART::CTRLC::CMODE_MSPI | to_underlying( usart_clock_phase )
+                | to_underlying( usart_bit_order ) ) },
             m_usart_baud{ usart_clock_generator_scaling_factor }
         {
         }

--- a/include/picolibrary/testing/interactive/microchip/megaavr0/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/log.h
@@ -32,6 +32,7 @@
 #include "picolibrary/precondition.h"
 #include "picolibrary/result.h"
 #include "picolibrary/stream.h"
+#include "picolibrary/utility.h"
 #include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Interactive::Microchip::megaAVR0 {
@@ -84,7 +85,7 @@ class Log : public Output_Stream {
 
         ::picolibrary::Microchip::megaAVR0::Multiplexed_Signals::set_usart_route( usart, usart_route );
 
-        usart.ctrlb = static_cast<std::uint8_t>( usart_clock_generator_operating_speed );
+        usart.ctrlb = to_underlying( usart_clock_generator_operating_speed );
         usart.ctrlc = ::picolibrary::Microchip::megaAVR0::Peripheral::USART::CTRLC::CMODE_ASYNCHRONOUS
                       | ::picolibrary::Microchip::megaAVR0::Peripheral::USART::CTRLC::PMODE_DISABLED
                       | ::picolibrary::Microchip::megaAVR0::Peripheral::USART::CTRLC::CHSIZE_8BIT;


### PR DESCRIPTION
Resolves #660 (Replace static casts with enum underlying type conversion
utility calls).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
