### PR TITLE
Replace return type deduction with explicit return types where reasonable

### DIFF
--- a/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
+++ b/include/picolibrary/microchip/megaavr0/asynchronous_serial.h
@@ -149,7 +149,7 @@ class Basic_Transmitter {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Basic_Transmitter && expression ) noexcept
+    constexpr auto operator=( Basic_Transmitter && expression ) noexcept -> Basic_Transmitter &
     {
         if ( &expression != this ) {
             disable();

--- a/include/picolibrary/microchip/megaavr0/clock.h
+++ b/include/picolibrary/microchip/megaavr0/clock.h
@@ -62,7 +62,7 @@ inline auto source_changing() noexcept -> bool
  *
  * \return The clock source.
  */
-inline auto source() noexcept
+inline auto source() noexcept -> Source
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -158,7 +158,7 @@ inline auto prescaler_enabled() noexcept -> bool
  *
  * \return The clock prescaler configuration.
  */
-inline auto prescaler_configuration() noexcept
+inline auto prescaler_configuration() noexcept -> Prescaler
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -170,7 +170,7 @@ inline auto prescaler_configuration() noexcept
  *
  * \return The clock prescaler value.
  */
-inline auto prescaler_value() noexcept
+inline auto prescaler_value() noexcept -> Prescaler_Value
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -259,7 +259,7 @@ inline auto internal_16_20_MHz_oscillator_stable() noexcept -> bool
  *
  * \return The internal 16/20 MHz oscillator mode.
  */
-inline auto internal_16_20_MHz_oscillator_mode() noexcept
+inline auto internal_16_20_MHz_oscillator_mode() noexcept -> Internal_16_20_MHz_Oscillator_Mode
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -336,6 +336,7 @@ inline auto internal_32_768_kHz_ultra_low_power_oscillator_stable() noexcept -> 
  * \return The internal 32.768 kHz ultra low-power oscillator mode.
  */
 inline auto internal_32_768_kHz_ultra_low_power_oscillator_mode() noexcept
+    -> Internal_32_768_kHz_Ultra_Low_Power_Oscillator_Mode
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -399,7 +400,7 @@ inline auto external_32_768_kHz_crystal_oscillator_stable() noexcept -> bool
  *
  * \return The external 32.768 kHz crystal oscillator source.
  */
-inline auto external_32_768_kHz_crystal_oscillator_source() noexcept
+inline auto external_32_768_kHz_crystal_oscillator_source() noexcept -> External_32_768_kHz_Crystal_Oscillator_Source
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -413,6 +414,7 @@ inline auto external_32_768_kHz_crystal_oscillator_source() noexcept
  * \return The external 32.768 kHz crystal oscillator start-up time.
  */
 inline auto external_32_768_kHz_crystal_oscillator_start_up_time() noexcept
+    -> External_32_768_kHz_Crystal_Oscillator_Start_Up_Time
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 
@@ -425,7 +427,7 @@ inline auto external_32_768_kHz_crystal_oscillator_start_up_time() noexcept
  *
  * \return The external 32.768 kHz crystal oscillator mode.
  */
-inline auto external_32_768_kHz_crystal_oscillator_mode() noexcept
+inline auto external_32_768_kHz_crystal_oscillator_mode() noexcept -> External_32_768_kHz_Crystal_Oscillator_Mode
 {
     auto const & clkctrl = Peripheral::CLKCTRL0::instance();
 

--- a/include/picolibrary/microchip/megaavr0/gpio.h
+++ b/include/picolibrary/microchip/megaavr0/gpio.h
@@ -95,7 +95,7 @@ class Pin<Peripheral::PORT> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Pin && expression ) noexcept
+    constexpr auto operator=( Pin && expression ) noexcept -> Pin &
     {
         if ( &expression != this ) {
             m_port = expression.m_port;
@@ -162,7 +162,7 @@ class Pin<Peripheral::PORT> {
      * \return false if the internally pulled-up input pin's internal pull-up resistor is
      *         not disabled.
      */
-    auto pull_up_is_disabled() const noexcept
+    auto pull_up_is_disabled() const noexcept -> bool
     {
         return not pull_up_is_enabled();
     }
@@ -224,7 +224,7 @@ class Pin<Peripheral::PORT> {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return not is_high();
     }
@@ -350,7 +350,7 @@ class Pin<Peripheral::VPORT> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Pin && expression ) noexcept
+    constexpr auto operator=( Pin && expression ) noexcept -> Pin &
     {
         if ( &expression != this ) {
             m_vport = expression.m_vport;
@@ -406,7 +406,7 @@ class Pin<Peripheral::VPORT> {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return not is_high();
     }
@@ -547,7 +547,7 @@ class Input_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -558,7 +558,7 @@ class Input_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -619,7 +619,8 @@ class Internally_Pulled_Up_Input_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+    constexpr auto operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+        -> Internally_Pulled_Up_Input_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -658,7 +659,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin's internal pull-up resistor is disabled.
      * \return false if the pin's internal pull-up resistor is not disabled.
      */
-    auto pull_up_is_disabled() const noexcept
+    auto pull_up_is_disabled() const noexcept -> bool
     {
         return m_pin.pull_up_is_disabled();
     }
@@ -669,7 +670,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin's internal pull-up resistor is enabled.
      * \return false if the pin's internal pull-up resistor is not enabled.
      */
-    auto pull_up_is_enabled() const noexcept
+    auto pull_up_is_enabled() const noexcept -> bool
     {
         return m_pin.pull_up_is_enabled();
     }
@@ -696,7 +697,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -707,7 +708,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -779,7 +780,7 @@ class Open_Drain_IO_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Open_Drain_IO_Pin && expression ) noexcept
+    constexpr auto operator=( Open_Drain_IO_Pin && expression ) noexcept -> Open_Drain_IO_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -817,7 +818,7 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -828,7 +829,7 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -924,7 +925,7 @@ class Push_Pull_IO_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Push_Pull_IO_Pin && expression ) noexcept
+    constexpr auto operator=( Push_Pull_IO_Pin && expression ) noexcept -> Push_Pull_IO_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -962,7 +963,7 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -973,7 +974,7 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }

--- a/include/picolibrary/microchip/megaavr0/i2c.h
+++ b/include/picolibrary/microchip/megaavr0/i2c.h
@@ -125,7 +125,7 @@ class Basic_Controller {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Basic_Controller && expression ) noexcept -> Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -156,7 +156,7 @@ class Basic_Controller {
      * \return true if a bus error is present.
      * \return false if a bus error is not present.
      */
-    auto bus_error_present() const noexcept
+    auto bus_error_present() const noexcept -> bool
     {
         return controller_bus_error_present();
     }
@@ -196,6 +196,7 @@ class Basic_Controller {
      * \return picolibrary::I2C::Response::NACK if a NACK response is received.
      */
     auto address( ::picolibrary::I2C::Address_Transmitted address, ::picolibrary::I2C::Operation operation ) noexcept
+        -> ::picolibrary::I2C::Response
     {
         initiate_addressing( address, operation );
 
@@ -216,7 +217,7 @@ class Basic_Controller {
      *
      * \return The data read from the device.
      */
-    auto read( ::picolibrary::I2C::Response response ) noexcept
+    auto read( ::picolibrary::I2C::Response response ) noexcept -> std::uint8_t
     {
         configure_read_response( response );
 
@@ -235,7 +236,7 @@ class Basic_Controller {
      * \return picolibrary::I2C::Response::ACK if an ACK response is received.
      * \return picolibrary::I2C::Response::NACK if a NACK response is received.
      */
-    auto write( std::uint8_t data ) noexcept
+    auto write( std::uint8_t data ) noexcept -> ::picolibrary::I2C::Response
     {
         initiate_write( data );
 

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/spi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/spi.h
@@ -130,7 +130,7 @@ constexpr auto spi_port_address( std::uintptr_t spi_address, SPI_Route route ) n
  *
  * \return The SPI peripheral's pins PORT peripheral.
  */
-inline auto & spi_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto spi_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         spi_port_address( reinterpret_cast<std::uintptr_t>( &spi ), route ) );
@@ -143,7 +143,7 @@ inline auto & spi_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's pins PORT peripheral.
  */
-inline auto & spi_port( Peripheral::SPI const & spi ) noexcept
+inline auto spi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi, spi_route( spi ) );
 }
@@ -186,7 +186,7 @@ constexpr auto spi_vport_address( std::uintptr_t spi_address, SPI_Route route ) 
  *
  * \return The SPI peripheral's pins VPORT peripheral.
  */
-inline auto & spi_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto spi_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::VPORT &
 {
     return *reinterpret_cast<Peripheral::VPORT *>(
         spi_vport_address( reinterpret_cast<std::uintptr_t>( &spi ), route ) );
@@ -199,7 +199,7 @@ inline auto & spi_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's pins VPORT peripheral.
  */
-inline auto & spi_vport( Peripheral::SPI const & spi ) noexcept
+inline auto spi_vport( Peripheral::SPI const & spi ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi, spi_route( spi ) );
 }
@@ -213,7 +213,7 @@ inline auto & spi_vport( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SS pin PORT peripheral address.
  */
-constexpr auto ss_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto ss_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address, route );
 }
@@ -226,7 +226,7 @@ constexpr auto ss_port_address( std::uintptr_t spi_address, SPI_Route route ) no
  *
  * \return The SPI peripheral's SS pin PORT peripheral.
  */
-inline auto & ss_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto ss_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi, route );
 }
@@ -238,7 +238,7 @@ inline auto & ss_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SS pin PORT peripheral.
  */
-inline auto & ss_port( Peripheral::SPI const & spi ) noexcept
+inline auto ss_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -252,7 +252,7 @@ inline auto & ss_port( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SS pin VPORT peripheral address.
  */
-constexpr auto ss_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto ss_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_vport_address( spi_address, route );
 }
@@ -265,7 +265,7 @@ constexpr auto ss_vport_address( std::uintptr_t spi_address, SPI_Route route ) n
  *
  * \return The SPI peripheral's SS pin VPORT peripheral.
  */
-inline auto & ss_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto ss_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi, route );
 }
@@ -277,7 +277,7 @@ inline auto & ss_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SS pin VPORT peripheral.
  */
-inline auto & ss_vport( Peripheral::SPI const & spi ) noexcept
+inline auto ss_vport( Peripheral::SPI const & spi ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi );
 }
@@ -320,7 +320,7 @@ constexpr auto ss_number( std::uintptr_t spi_address, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SS pin number.
  */
-inline auto ss_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto ss_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint_fast8_t
 {
     return ss_number( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -332,7 +332,7 @@ inline auto ss_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SS pin number.
  */
-inline auto ss_number( Peripheral::SPI const & spi ) noexcept
+inline auto ss_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return ss_number( spi, spi_route( spi ) );
 }
@@ -359,7 +359,7 @@ constexpr auto ss_mask( std::uintptr_t spi_address, SPI_Route route ) noexcept -
  *
  * \return The SPI peripheral's SS pin mask.
  */
-inline auto ss_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto ss_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint8_t
 {
     return ss_mask( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -371,7 +371,7 @@ inline auto ss_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SS pin mask.
  */
-inline auto ss_mask( Peripheral::SPI const & spi ) noexcept
+inline auto ss_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return ss_mask( spi, spi_route( spi ) );
 }
@@ -385,7 +385,7 @@ inline auto ss_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SCK pin PORT peripheral address.
  */
-constexpr auto sck_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto sck_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address, route );
 }
@@ -398,7 +398,7 @@ constexpr auto sck_port_address( std::uintptr_t spi_address, SPI_Route route ) n
  *
  * \return The SPI peripheral's SCK pin PORT peripheral.
  */
-inline auto & sck_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto sck_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi, route );
 }
@@ -410,7 +410,7 @@ inline auto & sck_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SCK pin PORT peripheral.
  */
-inline auto & sck_port( Peripheral::SPI const & spi ) noexcept
+inline auto sck_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -424,7 +424,7 @@ inline auto & sck_port( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's SCK pin VPORT peripheral address.
  */
-constexpr auto sck_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto sck_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_vport_address( spi_address, route );
 }
@@ -437,7 +437,7 @@ constexpr auto sck_vport_address( std::uintptr_t spi_address, SPI_Route route ) 
  *
  * \return The SPI peripheral's SCK pin VPORT peripheral.
  */
-inline auto & sck_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto sck_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi, route );
 }
@@ -449,7 +449,7 @@ inline auto & sck_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SCK pin VPORT peripheral.
  */
-inline auto & sck_vport( Peripheral::SPI const & spi ) noexcept
+inline auto sck_vport( Peripheral::SPI const & spi ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi );
 }
@@ -492,7 +492,7 @@ constexpr auto sck_number( std::uintptr_t spi_address, SPI_Route route ) noexcep
  *
  * \return The SPI peripheral's SCK pin number.
  */
-inline auto sck_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto sck_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint_fast8_t
 {
     return sck_number( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -504,7 +504,7 @@ inline auto sck_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SCK pin number.
  */
-inline auto sck_number( Peripheral::SPI const & spi ) noexcept
+inline auto sck_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return sck_number( spi, spi_route( spi ) );
 }
@@ -531,7 +531,7 @@ constexpr auto sck_mask( std::uintptr_t spi_address, SPI_Route route ) noexcept 
  *
  * \return The SPI peripheral's SCK pin mask.
  */
-inline auto sck_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto sck_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint8_t
 {
     return sck_mask( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -543,7 +543,7 @@ inline auto sck_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's SCK pin mask.
  */
-inline auto sck_mask( Peripheral::SPI const & spi ) noexcept
+inline auto sck_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return sck_mask( spi, spi_route( spi ) );
 }
@@ -557,7 +557,7 @@ inline auto sck_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral address.
  */
-constexpr auto mosi_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto mosi_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address, route );
 }
@@ -570,7 +570,7 @@ constexpr auto mosi_port_address( std::uintptr_t spi_address, SPI_Route route ) 
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral.
  */
-inline auto & mosi_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto mosi_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi, route );
 }
@@ -582,7 +582,7 @@ inline auto & mosi_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MOSI pin PORT peripheral.
  */
-inline auto & mosi_port( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -596,7 +596,7 @@ inline auto & mosi_port( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MOSI pin VPORT peripheral address.
  */
-constexpr auto mosi_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto mosi_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_vport_address( spi_address, route );
 }
@@ -609,7 +609,7 @@ constexpr auto mosi_vport_address( std::uintptr_t spi_address, SPI_Route route )
  *
  * \return The SPI peripheral's MOSI pin VPORT peripheral.
  */
-inline auto & mosi_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto mosi_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi, route );
 }
@@ -621,7 +621,7 @@ inline auto & mosi_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcep
  *
  * \return The SPI peripheral's MOSI pin VPORT peripheral.
  */
-inline auto & mosi_vport( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_vport( Peripheral::SPI const & spi ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi );
 }
@@ -664,7 +664,7 @@ constexpr auto mosi_number( std::uintptr_t spi_address, SPI_Route route ) noexce
  *
  * \return The SPI peripheral's MOSI pin number.
  */
-inline auto mosi_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto mosi_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint_fast8_t
 {
     return mosi_number( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -676,7 +676,7 @@ inline auto mosi_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MOSI pin number.
  */
-inline auto mosi_number( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return mosi_number( spi, spi_route( spi ) );
 }
@@ -703,7 +703,7 @@ constexpr auto mosi_mask( std::uintptr_t spi_address, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MOSI pin mask.
  */
-inline auto mosi_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto mosi_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint8_t
 {
     return mosi_mask( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -715,7 +715,7 @@ inline auto mosi_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MOSI pin mask.
  */
-inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept
+inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return mosi_mask( spi, spi_route( spi ) );
 }
@@ -729,7 +729,7 @@ inline auto mosi_mask( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MISO pin PORT peripheral address.
  */
-constexpr auto miso_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto miso_port_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_port_address( spi_address, route );
 }
@@ -742,7 +742,7 @@ constexpr auto miso_port_address( std::uintptr_t spi_address, SPI_Route route ) 
  *
  * \return The SPI peripheral's MISO pin PORT peripheral.
  */
-inline auto & miso_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto miso_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi, route );
 }
@@ -754,7 +754,7 @@ inline auto & miso_port( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MISO pin PORT peripheral.
  */
-inline auto & miso_port( Peripheral::SPI const & spi ) noexcept
+inline auto miso_port( Peripheral::SPI const & spi ) noexcept -> Peripheral::PORT &
 {
     return spi_port( spi );
 }
@@ -768,7 +768,7 @@ inline auto & miso_port( Peripheral::SPI const & spi ) noexcept
  *
  * \return The SPI peripheral's MISO pin VPORT peripheral address.
  */
-constexpr auto miso_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept
+constexpr auto miso_vport_address( std::uintptr_t spi_address, SPI_Route route ) noexcept -> std::uintptr_t
 {
     return spi_vport_address( spi_address, route );
 }
@@ -781,7 +781,7 @@ constexpr auto miso_vport_address( std::uintptr_t spi_address, SPI_Route route )
  *
  * \return The SPI peripheral's MISO pin VPORT peripheral.
  */
-inline auto & miso_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto miso_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi, route );
 }
@@ -793,7 +793,7 @@ inline auto & miso_vport( Peripheral::SPI const & spi, SPI_Route route ) noexcep
  *
  * \return The SPI peripheral's MISO pin VPORT peripheral.
  */
-inline auto & miso_vport( Peripheral::SPI const & spi ) noexcept
+inline auto miso_vport( Peripheral::SPI const & spi ) noexcept -> Peripheral::VPORT &
 {
     return spi_vport( spi );
 }
@@ -836,7 +836,7 @@ constexpr auto miso_number( std::uintptr_t spi_address, SPI_Route route ) noexce
  *
  * \return The SPI peripheral's MISO pin number.
  */
-inline auto miso_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto miso_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint_fast8_t
 {
     return miso_number( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -848,7 +848,7 @@ inline auto miso_number( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MISO pin number.
  */
-inline auto miso_number( Peripheral::SPI const & spi ) noexcept
+inline auto miso_number( Peripheral::SPI const & spi ) noexcept -> std::uint_fast8_t
 {
     return miso_number( spi, spi_route( spi ) );
 }
@@ -875,7 +875,7 @@ constexpr auto miso_mask( std::uintptr_t spi_address, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MISO pin mask.
  */
-inline auto miso_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
+inline auto miso_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept -> std::uint8_t
 {
     return miso_mask( reinterpret_cast<std::uintptr_t>( &spi ), route );
 }
@@ -887,7 +887,7 @@ inline auto miso_mask( Peripheral::SPI const & spi, SPI_Route route ) noexcept
  *
  * \return The SPI peripheral's MISO pin mask.
  */
-inline auto miso_mask( Peripheral::SPI const & spi ) noexcept
+inline auto miso_mask( Peripheral::SPI const & spi ) noexcept -> std::uint8_t
 {
     return miso_mask( spi, spi_route( spi ) );
 }

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/twi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/twi.h
@@ -122,7 +122,7 @@ constexpr auto scl_number( std::uintptr_t twi_address, TWI_Route route ) noexcep
  *
  * \return The TWI peripheral's SCL pin number.
  */
-inline auto scl_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto scl_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint_fast8_t
 {
     return scl_number( reinterpret_cast<std::uintptr_t>( &twi ), route );
 }
@@ -134,7 +134,7 @@ inline auto scl_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
  *
  * \return The TWI peripheral's SCL pin number.
  */
-inline auto scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return scl_number( twi, twi_route( twi ) );
 }
@@ -161,7 +161,7 @@ constexpr auto scl_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept 
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-inline auto scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint8_t
 {
     return scl_mask( reinterpret_cast<std::uintptr_t>( &twi ), route );
 }
@@ -173,7 +173,7 @@ inline auto scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
  *
  * \return The TWI peripheral's SCL pin mask.
  */
-inline auto scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return scl_mask( twi, twi_route( twi ) );
 }
@@ -212,7 +212,7 @@ constexpr auto sda_number( std::uintptr_t twi_address, TWI_Route route ) noexcep
  *
  * \return The TWI peripheral's SDA pin number.
  */
-inline auto sda_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto sda_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint_fast8_t
 {
     return sda_number( reinterpret_cast<std::uintptr_t>( &twi ), route );
 }
@@ -224,7 +224,7 @@ inline auto sda_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
  *
  * \return The TWI peripheral's SDA pin number.
  */
-inline auto sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return sda_number( twi, twi_route( twi ) );
 }
@@ -251,7 +251,7 @@ constexpr auto sda_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept 
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-inline auto sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint8_t
 {
     return sda_mask( reinterpret_cast<std::uintptr_t>( &twi ), route );
 }
@@ -263,7 +263,7 @@ inline auto sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
  *
  * \return The TWI peripheral's SDA pin mask.
  */
-inline auto sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return sda_mask( twi, twi_route( twi ) );
 }
@@ -304,7 +304,8 @@ constexpr auto twi_controller_port_address( std::uintptr_t twi_address, TWI_Rout
  *
  * \return The TWI peripheral's controller pins PORT peripheral.
  */
-inline auto & twi_controller_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto twi_controller_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         twi_controller_port_address( reinterpret_cast<std::uintptr_t>( &twi ), route ) );
@@ -318,7 +319,7 @@ inline auto & twi_controller_port( Peripheral::TWI const & twi, TWI_Route route 
  *
  * \return The TWI peripheral's controller pins PORT peripheral.
  */
-inline auto & twi_controller_port( Peripheral::TWI const & twi ) noexcept
+inline auto twi_controller_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_controller_port( twi, twi_route( twi ) );
 }
@@ -359,7 +360,8 @@ constexpr auto twi_controller_vport_address( std::uintptr_t twi_address, TWI_Rou
  *
  * \return The TWI peripheral's controller pins VPORT peripheral.
  */
-inline auto & twi_controller_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto twi_controller_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return *reinterpret_cast<Peripheral::VPORT *>(
         twi_controller_vport_address( reinterpret_cast<std::uintptr_t>( &twi ), route ) );
@@ -373,7 +375,7 @@ inline auto & twi_controller_vport( Peripheral::TWI const & twi, TWI_Route route
  *
  * \return The TWI peripheral's controller pins VPORT peripheral.
  */
-inline auto & twi_controller_vport( Peripheral::TWI const & twi ) noexcept
+inline auto twi_controller_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
     return twi_controller_vport( twi, twi_route( twi ) );
 }
@@ -388,6 +390,7 @@ inline auto & twi_controller_vport( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's controller SCL pin PORT peripheral address.
  */
 constexpr auto controller_scl_port_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_controller_port_address( twi_address, route );
 }
@@ -401,7 +404,8 @@ constexpr auto controller_scl_port_address( std::uintptr_t twi_address, TWI_Rout
  *
  * \return The TWI peripheral's controller SCL pin PORT peripheral.
  */
-inline auto & controller_scl_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto controller_scl_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return twi_controller_port( twi, route );
 }
@@ -414,7 +418,7 @@ inline auto & controller_scl_port( Peripheral::TWI const & twi, TWI_Route route 
  *
  * \return The TWI peripheral's controller SCL pin PORT peripheral.
  */
-inline auto & controller_scl_port( Peripheral::TWI const & twi ) noexcept
+inline auto controller_scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_controller_port( twi );
 }
@@ -429,6 +433,7 @@ inline auto & controller_scl_port( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's controller SCL pin VPORT peripheral address.
  */
 constexpr auto controller_scl_vport_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_controller_vport_address( twi_address, route );
 }
@@ -442,7 +447,8 @@ constexpr auto controller_scl_vport_address( std::uintptr_t twi_address, TWI_Rou
  *
  * \return The TWI peripheral's controller SCL pin VPORT peripheral.
  */
-inline auto & controller_scl_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto controller_scl_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return twi_controller_vport( twi, route );
 }
@@ -455,7 +461,7 @@ inline auto & controller_scl_vport( Peripheral::TWI const & twi, TWI_Route route
  *
  * \return The TWI peripheral's controller SCL pin VPORT peripheral.
  */
-inline auto & controller_scl_vport( Peripheral::TWI const & twi ) noexcept
+inline auto controller_scl_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
     return twi_controller_vport( twi );
 }
@@ -470,6 +476,7 @@ inline auto & controller_scl_vport( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's controller SCL pin number.
  */
 constexpr auto controller_scl_number( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uint_fast8_t
 {
     return scl_number( twi_address, route );
 }
@@ -483,6 +490,7 @@ constexpr auto controller_scl_number( std::uintptr_t twi_address, TWI_Route rout
  * \return The TWI peripheral's controller SCL pin number.
  */
 inline auto controller_scl_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> std::uint_fast8_t
 {
     return scl_number( twi, route );
 }
@@ -494,7 +502,7 @@ inline auto controller_scl_number( Peripheral::TWI const & twi, TWI_Route route 
  *
  * \return The TWI peripheral's controller SCL pin number.
  */
-inline auto controller_scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto controller_scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return scl_number( twi );
 }
@@ -508,7 +516,7 @@ inline auto controller_scl_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's controller SCL pin mask.
  */
-constexpr auto controller_scl_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept
+constexpr auto controller_scl_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept -> std::uint8_t
 {
     return scl_mask( twi_address, route );
 }
@@ -521,7 +529,7 @@ constexpr auto controller_scl_mask( std::uintptr_t twi_address, TWI_Route route 
  *
  * \return The TWI peripheral's controller SCL pin mask.
  */
-inline auto controller_scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto controller_scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint8_t
 {
     return scl_mask( twi, route );
 }
@@ -533,7 +541,7 @@ inline auto controller_scl_mask( Peripheral::TWI const & twi, TWI_Route route ) 
  *
  * \return The TWI peripheral's controller SCL pin mask.
  */
-inline auto controller_scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto controller_scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return scl_mask( twi );
 }
@@ -548,6 +556,7 @@ inline auto controller_scl_mask( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's controller SDA pin PORT peripheral address.
  */
 constexpr auto controller_sda_port_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_controller_port_address( twi_address, route );
 }
@@ -561,7 +570,8 @@ constexpr auto controller_sda_port_address( std::uintptr_t twi_address, TWI_Rout
  *
  * \return The TWI peripheral's controller SDA pin PORT peripheral.
  */
-inline auto & controller_sda_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto controller_sda_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return twi_controller_port( twi, route );
 }
@@ -574,7 +584,7 @@ inline auto & controller_sda_port( Peripheral::TWI const & twi, TWI_Route route 
  *
  * \return The TWI peripheral's controller SDA pin PORT peripheral.
  */
-inline auto & controller_sda_port( Peripheral::TWI const & twi ) noexcept
+inline auto controller_sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_controller_port( twi );
 }
@@ -589,6 +599,7 @@ inline auto & controller_sda_port( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's controller SDA pin VPORT peripheral address.
  */
 constexpr auto controller_sda_vport_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_controller_vport_address( twi_address, route );
 }
@@ -602,7 +613,8 @@ constexpr auto controller_sda_vport_address( std::uintptr_t twi_address, TWI_Rou
  *
  * \return The TWI peripheral's controller SDA pin VPORT peripheral.
  */
-inline auto & controller_sda_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto controller_sda_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return twi_controller_vport( twi, route );
 }
@@ -615,7 +627,7 @@ inline auto & controller_sda_vport( Peripheral::TWI const & twi, TWI_Route route
  *
  * \return The TWI peripheral's controller SDA pin VPORT peripheral.
  */
-inline auto & controller_sda_vport( Peripheral::TWI const & twi ) noexcept
+inline auto controller_sda_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
     return twi_controller_vport( twi );
 }
@@ -630,6 +642,7 @@ inline auto & controller_sda_vport( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's controller SDA pin number.
  */
 constexpr auto controller_sda_number( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uint_fast8_t
 {
     return sda_number( twi_address, route );
 }
@@ -643,6 +656,7 @@ constexpr auto controller_sda_number( std::uintptr_t twi_address, TWI_Route rout
  * \return The TWI peripheral's controller SDA pin number.
  */
 inline auto controller_sda_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> std::uint_fast8_t
 {
     return sda_number( twi, route );
 }
@@ -654,7 +668,7 @@ inline auto controller_sda_number( Peripheral::TWI const & twi, TWI_Route route 
  *
  * \return The TWI peripheral's controller SDA pin number.
  */
-inline auto controller_sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto controller_sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return sda_number( twi );
 }
@@ -668,7 +682,7 @@ inline auto controller_sda_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's controller SDA pin mask.
  */
-constexpr auto controller_sda_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept
+constexpr auto controller_sda_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept -> std::uint8_t
 {
     return sda_mask( twi_address, route );
 }
@@ -681,7 +695,7 @@ constexpr auto controller_sda_mask( std::uintptr_t twi_address, TWI_Route route 
  *
  * \return The TWI peripheral's controller SDA pin mask.
  */
-inline auto controller_sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto controller_sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint8_t
 {
     return sda_mask( twi, route );
 }
@@ -693,7 +707,7 @@ inline auto controller_sda_mask( Peripheral::TWI const & twi, TWI_Route route ) 
  *
  * \return The TWI peripheral's controller SDA pin mask.
  */
-inline auto controller_sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto controller_sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return sda_mask( twi );
 }
@@ -733,7 +747,8 @@ constexpr auto twi_device_port_address( std::uintptr_t twi_address, TWI_Route ro
  *
  * \return The TWI peripheral's device pins PORT peripheral.
  */
-inline auto & twi_device_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto twi_device_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         twi_device_port_address( reinterpret_cast<std::uintptr_t>( &twi ), route ) );
@@ -746,7 +761,7 @@ inline auto & twi_device_port( Peripheral::TWI const & twi, TWI_Route route ) no
  *
  * \return The TWI peripheral's device pins PORT peripheral.
  */
-inline auto & twi_device_port( Peripheral::TWI const & twi ) noexcept
+inline auto twi_device_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_device_port( twi, twi_route( twi ) );
 }
@@ -787,7 +802,8 @@ constexpr auto twi_device_vport_address( std::uintptr_t twi_address, TWI_Route r
  *
  * \return The TWI peripheral's device pins VPORT peripheral.
  */
-inline auto & twi_device_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto twi_device_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return *reinterpret_cast<Peripheral::VPORT *>(
         twi_device_vport_address( reinterpret_cast<std::uintptr_t>( &twi ), route ) );
@@ -801,7 +817,7 @@ inline auto & twi_device_vport( Peripheral::TWI const & twi, TWI_Route route ) n
  *
  * \return The TWI peripheral's device pins VPORT peripheral.
  */
-inline auto & twi_device_vport( Peripheral::TWI const & twi ) noexcept
+inline auto twi_device_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
     return twi_device_vport( twi, twi_route( twi ) );
 }
@@ -816,6 +832,7 @@ inline auto & twi_device_vport( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's device SCL pin PORT peripheral address.
  */
 constexpr auto device_scl_port_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_device_port_address( twi_address, route );
 }
@@ -829,7 +846,8 @@ constexpr auto device_scl_port_address( std::uintptr_t twi_address, TWI_Route ro
  *
  * \return The TWI peripheral's device SCL pin PORT peripheral.
  */
-inline auto & device_scl_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_scl_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return twi_device_port( twi, route );
 }
@@ -842,7 +860,7 @@ inline auto & device_scl_port( Peripheral::TWI const & twi, TWI_Route route ) no
  *
  * \return The TWI peripheral's device SCL pin PORT peripheral.
  */
-inline auto & device_scl_port( Peripheral::TWI const & twi ) noexcept
+inline auto device_scl_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_device_port( twi );
 }
@@ -857,6 +875,7 @@ inline auto & device_scl_port( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's device SCL pin VPORT peripheral address.
  */
 constexpr auto device_scl_vport_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_device_vport_address( twi_address, route );
 }
@@ -870,7 +889,8 @@ constexpr auto device_scl_vport_address( std::uintptr_t twi_address, TWI_Route r
  *
  * \return The TWI peripheral's device SCL pin VPORT peripheral.
  */
-inline auto & device_scl_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_scl_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return twi_device_vport( twi, route );
 }
@@ -883,7 +903,7 @@ inline auto & device_scl_vport( Peripheral::TWI const & twi, TWI_Route route ) n
  *
  * \return The TWI peripheral's device SCL pin VPORT peripheral.
  */
-inline auto & device_scl_vport( Peripheral::TWI const & twi ) noexcept
+inline auto device_scl_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
     return twi_device_vport( twi );
 }
@@ -897,7 +917,7 @@ inline auto & device_scl_vport( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SCL pin number.
  */
-constexpr auto device_scl_number( std::uintptr_t twi_address, TWI_Route route ) noexcept
+constexpr auto device_scl_number( std::uintptr_t twi_address, TWI_Route route ) noexcept -> std::uint_fast8_t
 {
     return scl_number( twi_address, route );
 }
@@ -910,7 +930,7 @@ constexpr auto device_scl_number( std::uintptr_t twi_address, TWI_Route route ) 
  *
  * \return The TWI peripheral's device SCL pin number.
  */
-inline auto device_scl_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_scl_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint_fast8_t
 {
     return scl_number( twi, route );
 }
@@ -922,7 +942,7 @@ inline auto device_scl_number( Peripheral::TWI const & twi, TWI_Route route ) no
  *
  * \return The TWI peripheral's device SCL pin number.
  */
-inline auto device_scl_number( Peripheral::TWI const & twi ) noexcept
+inline auto device_scl_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return scl_number( twi );
 }
@@ -936,7 +956,7 @@ inline auto device_scl_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SCL pin mask.
  */
-constexpr auto device_scl_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept
+constexpr auto device_scl_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept -> std::uint8_t
 {
     return scl_mask( twi_address, route );
 }
@@ -949,7 +969,7 @@ constexpr auto device_scl_mask( std::uintptr_t twi_address, TWI_Route route ) no
  *
  * \return The TWI peripheral's device SCL pin mask.
  */
-inline auto device_scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint8_t
 {
     return scl_mask( twi, route );
 }
@@ -961,7 +981,7 @@ inline auto device_scl_mask( Peripheral::TWI const & twi, TWI_Route route ) noex
  *
  * \return The TWI peripheral's device SCL pin mask.
  */
-inline auto device_scl_mask( Peripheral::TWI const & twi ) noexcept
+inline auto device_scl_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return scl_mask( twi );
 }
@@ -976,6 +996,7 @@ inline auto device_scl_mask( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's device SDA pin PORT peripheral address.
  */
 constexpr auto device_sda_port_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_device_port_address( twi_address, route );
 }
@@ -989,7 +1010,8 @@ constexpr auto device_sda_port_address( std::uintptr_t twi_address, TWI_Route ro
  *
  * \return The TWI peripheral's device SDA pin PORT peripheral.
  */
-inline auto & device_sda_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_sda_port( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return twi_device_port( twi, route );
 }
@@ -1002,7 +1024,7 @@ inline auto & device_sda_port( Peripheral::TWI const & twi, TWI_Route route ) no
  *
  * \return The TWI peripheral's device SDA pin PORT peripheral.
  */
-inline auto & device_sda_port( Peripheral::TWI const & twi ) noexcept
+inline auto device_sda_port( Peripheral::TWI const & twi ) noexcept -> Peripheral::PORT &
 {
     return twi_device_port( twi );
 }
@@ -1017,6 +1039,7 @@ inline auto & device_sda_port( Peripheral::TWI const & twi ) noexcept
  * \return The TWI peripheral's device SDA pin VPORT peripheral address.
  */
 constexpr auto device_sda_vport_address( std::uintptr_t twi_address, TWI_Route route ) noexcept
+    -> std::uintptr_t
 {
     return twi_device_vport_address( twi_address, route );
 }
@@ -1030,7 +1053,8 @@ constexpr auto device_sda_vport_address( std::uintptr_t twi_address, TWI_Route r
  *
  * \return The TWI peripheral's device SDA pin VPORT peripheral.
  */
-inline auto & device_sda_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_sda_vport( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return twi_device_vport( twi, route );
 }
@@ -1043,7 +1067,7 @@ inline auto & device_sda_vport( Peripheral::TWI const & twi, TWI_Route route ) n
  *
  * \return The TWI peripheral's device SDA pin VPORT peripheral.
  */
-inline auto & device_sda_vport( Peripheral::TWI const & twi ) noexcept
+inline auto device_sda_vport( Peripheral::TWI const & twi ) noexcept -> Peripheral::VPORT &
 {
     return twi_device_vport( twi );
 }
@@ -1057,7 +1081,7 @@ inline auto & device_sda_vport( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SDA pin number.
  */
-constexpr auto device_sda_number( std::uintptr_t twi_address, TWI_Route route ) noexcept
+constexpr auto device_sda_number( std::uintptr_t twi_address, TWI_Route route ) noexcept -> std::uint_fast8_t
 {
     return sda_number( twi_address, route );
 }
@@ -1070,7 +1094,7 @@ constexpr auto device_sda_number( std::uintptr_t twi_address, TWI_Route route ) 
  *
  * \return The TWI peripheral's device SDA pin number.
  */
-inline auto device_sda_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_sda_number( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint_fast8_t
 {
     return sda_number( twi, route );
 }
@@ -1082,7 +1106,7 @@ inline auto device_sda_number( Peripheral::TWI const & twi, TWI_Route route ) no
  *
  * \return The TWI peripheral's device SDA pin number.
  */
-inline auto device_sda_number( Peripheral::TWI const & twi ) noexcept
+inline auto device_sda_number( Peripheral::TWI const & twi ) noexcept -> std::uint_fast8_t
 {
     return sda_number( twi );
 }
@@ -1096,7 +1120,7 @@ inline auto device_sda_number( Peripheral::TWI const & twi ) noexcept
  *
  * \return The TWI peripheral's device SDA pin mask.
  */
-constexpr auto device_sda_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept
+constexpr auto device_sda_mask( std::uintptr_t twi_address, TWI_Route route ) noexcept -> std::uint8_t
 {
     return sda_mask( twi_address, route );
 }
@@ -1109,7 +1133,7 @@ constexpr auto device_sda_mask( std::uintptr_t twi_address, TWI_Route route ) no
  *
  * \return The TWI peripheral's device SDA pin mask.
  */
-inline auto device_sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept
+inline auto device_sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noexcept -> std::uint8_t
 {
     return sda_mask( twi, route );
 }
@@ -1121,7 +1145,7 @@ inline auto device_sda_mask( Peripheral::TWI const & twi, TWI_Route route ) noex
  *
  * \return The TWI peripheral's device SDA pin mask.
  */
-inline auto device_sda_mask( Peripheral::TWI const & twi ) noexcept
+inline auto device_sda_mask( Peripheral::TWI const & twi ) noexcept -> std::uint8_t
 {
     return sda_mask( twi );
 }

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
@@ -187,7 +187,8 @@ constexpr auto usart_port_address( std::uintptr_t usart_address, USART_Route rou
  *
  * \return The USART peripheral's pins PORT peripheral.
  */
-inline auto & usart_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto usart_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return *reinterpret_cast<Peripheral::PORT *>(
         usart_port_address( reinterpret_cast<std::uintptr_t>( &usart ), route ) );
@@ -200,7 +201,7 @@ inline auto & usart_port( Peripheral::USART const & usart, USART_Route route ) n
  *
  * \return The USART peripheral's pins PORT peripheral.
  */
-inline auto & usart_port( Peripheral::USART const & usart ) noexcept
+inline auto usart_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart, usart_route( usart ) );
 }
@@ -266,7 +267,8 @@ constexpr auto usart_vport_address( std::uintptr_t usart_address, USART_Route ro
  *
  * \return The USART peripheral's pins VPORT peripheral.
  */
-inline auto & usart_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto usart_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return *reinterpret_cast<Peripheral::VPORT *>(
         usart_vport_address( reinterpret_cast<std::uintptr_t>( &usart ), route ) );
@@ -279,7 +281,7 @@ inline auto & usart_vport( Peripheral::USART const & usart, USART_Route route ) 
  *
  * \return The USART peripheral's pins VPORT peripheral.
  */
-inline auto & usart_vport( Peripheral::USART const & usart ) noexcept
+inline auto usart_vport( Peripheral::USART const & usart ) noexcept -> Peripheral::VPORT &
 {
     return usart_vport( usart, usart_route( usart ) );
 }
@@ -294,6 +296,7 @@ inline auto & usart_vport( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's XCK pin PORT peripheral address.
  */
 constexpr auto xck_port_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_port_address( usart_address, route );
 }
@@ -306,7 +309,8 @@ constexpr auto xck_port_address( std::uintptr_t usart_address, USART_Route route
  *
  * \return The USART peripheral's XCK pin PORT peripheral.
  */
-inline auto & xck_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xck_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return usart_port( usart, route );
 }
@@ -318,7 +322,7 @@ inline auto & xck_port( Peripheral::USART const & usart, USART_Route route ) noe
  *
  * \return The USART peripheral's XCK pin PORT peripheral.
  */
-inline auto & xck_port( Peripheral::USART const & usart ) noexcept
+inline auto xck_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -333,6 +337,7 @@ inline auto & xck_port( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's XCK pin VPORT peripheral address.
  */
 constexpr auto xck_vport_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_vport_address( usart_address, route );
 }
@@ -346,7 +351,8 @@ constexpr auto xck_vport_address( std::uintptr_t usart_address, USART_Route rout
  *
  * \return The USART peripheral's XCK pin VPORT peripheral.
  */
-inline auto & xck_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xck_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return usart_vport( usart, route );
 }
@@ -359,7 +365,7 @@ inline auto & xck_vport( Peripheral::USART const & usart, USART_Route route ) no
  *
  * \return The USART peripheral's XCK pin VPORT peripheral.
  */
-inline auto & xck_vport( Peripheral::USART const & usart ) noexcept
+inline auto xck_vport( Peripheral::USART const & usart ) noexcept -> Peripheral::VPORT &
 {
     return usart_vport( usart );
 }
@@ -424,7 +430,7 @@ constexpr auto xck_number( std::uintptr_t usart_address, USART_Route route ) noe
  *
  * \return The USART peripheral's XCK pin number.
  */
-inline auto xck_number( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xck_number( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint_fast8_t
 {
     return xck_number( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -436,7 +442,7 @@ inline auto xck_number( Peripheral::USART const & usart, USART_Route route ) noe
  *
  * \return The USART peripheral's XCK pin number.
  */
-inline auto xck_number( Peripheral::USART const & usart ) noexcept
+inline auto xck_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return xck_number( usart, usart_route( usart ) );
 }
@@ -463,7 +469,7 @@ constexpr auto xck_mask( std::uintptr_t usart_address, USART_Route route ) noexc
  *
  * \return The USART peripheral's XCK pin mask.
  */
-inline auto xck_mask( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xck_mask( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint8_t
 {
     return xck_mask( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -475,7 +481,7 @@ inline auto xck_mask( Peripheral::USART const & usart, USART_Route route ) noexc
  *
  * \return The USART peripheral's XCK pin mask.
  */
-inline auto xck_mask( Peripheral::USART const & usart ) noexcept
+inline auto xck_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return xck_mask( usart, usart_route( usart ) );
 }
@@ -490,6 +496,7 @@ inline auto xck_mask( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's XDIR pin PORT peripheral address.
  */
 constexpr auto xdir_port_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_port_address( usart_address, route );
 }
@@ -503,7 +510,8 @@ constexpr auto xdir_port_address( std::uintptr_t usart_address, USART_Route rout
  *
  * \return The USART peripheral's XDIR pin PORT peripheral.
  */
-inline auto & xdir_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xdir_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return usart_port( usart, route );
 }
@@ -516,7 +524,7 @@ inline auto & xdir_port( Peripheral::USART const & usart, USART_Route route ) no
  *
  * \return The USART peripheral's XDIR pin PORT peripheral.
  */
-inline auto & xdir_port( Peripheral::USART const & usart ) noexcept
+inline auto xdir_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -531,6 +539,7 @@ inline auto & xdir_port( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's XDIR pin VPORT peripheral address.
  */
 constexpr auto xdir_vport_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_vport_address( usart_address, route );
 }
@@ -544,7 +553,8 @@ constexpr auto xdir_vport_address( std::uintptr_t usart_address, USART_Route rou
  *
  * \return The USART peripheral's XDIR pin VPORT peripheral.
  */
-inline auto & xdir_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xdir_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return usart_vport( usart, route );
 }
@@ -557,7 +567,7 @@ inline auto & xdir_vport( Peripheral::USART const & usart, USART_Route route ) n
  *
  * \return The USART peripheral's XDIR pin VPORT peripheral.
  */
-inline auto & xdir_vport( Peripheral::USART const & usart ) noexcept
+inline auto xdir_vport( Peripheral::USART const & usart ) noexcept -> Peripheral::VPORT &
 {
     return usart_vport( usart );
 }
@@ -622,7 +632,7 @@ constexpr auto xdir_number( std::uintptr_t usart_address, USART_Route route ) no
  *
  * \return The USART peripheral's XDIR pin number.
  */
-inline auto xdir_number( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xdir_number( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint_fast8_t
 {
     return xdir_number( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -634,7 +644,7 @@ inline auto xdir_number( Peripheral::USART const & usart, USART_Route route ) no
  *
  * \return The USART peripheral's XDIR pin number.
  */
-inline auto xdir_number( Peripheral::USART const & usart ) noexcept
+inline auto xdir_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return xdir_number( usart, usart_route( usart ) );
 }
@@ -661,7 +671,7 @@ constexpr auto xdir_mask( std::uintptr_t usart_address, USART_Route route ) noex
  *
  * \return The USART peripheral's XDIR pin mask.
  */
-inline auto xdir_mask( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto xdir_mask( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint8_t
 {
     return xdir_mask( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -673,7 +683,7 @@ inline auto xdir_mask( Peripheral::USART const & usart, USART_Route route ) noex
  *
  * \return The USART peripheral's XDIR pin mask.
  */
-inline auto xdir_mask( Peripheral::USART const & usart ) noexcept
+inline auto xdir_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return xdir_mask( usart, usart_route( usart ) );
 }
@@ -688,6 +698,7 @@ inline auto xdir_mask( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's TXD pin PORT peripheral address.
  */
 constexpr auto txd_port_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_port_address( usart_address, route );
 }
@@ -700,7 +711,8 @@ constexpr auto txd_port_address( std::uintptr_t usart_address, USART_Route route
  *
  * \return The USART peripheral's TXD pin PORT peripheral.
  */
-inline auto & txd_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto txd_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return usart_port( usart, route );
 }
@@ -712,7 +724,7 @@ inline auto & txd_port( Peripheral::USART const & usart, USART_Route route ) noe
  *
  * \return The USART peripheral's TXD pin PORT peripheral.
  */
-inline auto & txd_port( Peripheral::USART const & usart ) noexcept
+inline auto txd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -727,6 +739,7 @@ inline auto & txd_port( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's TXD pin VPORT peripheral address.
  */
 constexpr auto txd_vport_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_vport_address( usart_address, route );
 }
@@ -740,7 +753,8 @@ constexpr auto txd_vport_address( std::uintptr_t usart_address, USART_Route rout
  *
  * \return The USART peripheral's TXD pin VPORT peripheral.
  */
-inline auto & txd_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto txd_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return usart_vport( usart, route );
 }
@@ -753,7 +767,7 @@ inline auto & txd_vport( Peripheral::USART const & usart, USART_Route route ) no
  *
  * \return The USART peripheral's TXD pin VPORT peripheral.
  */
-inline auto & txd_vport( Peripheral::USART const & usart ) noexcept
+inline auto txd_vport( Peripheral::USART const & usart ) noexcept -> Peripheral::VPORT &
 {
     return usart_vport( usart );
 }
@@ -818,7 +832,7 @@ constexpr auto txd_number( std::uintptr_t usart_address, USART_Route route ) noe
  *
  * \return The USART peripheral's TXD pin number.
  */
-inline auto txd_number( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto txd_number( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint_fast8_t
 {
     return txd_number( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -830,7 +844,7 @@ inline auto txd_number( Peripheral::USART const & usart, USART_Route route ) noe
  *
  * \return The USART peripheral's TXD pin number.
  */
-inline auto txd_number( Peripheral::USART const & usart ) noexcept
+inline auto txd_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return txd_number( usart, usart_route( usart ) );
 }
@@ -857,7 +871,7 @@ constexpr auto txd_mask( std::uintptr_t usart_address, USART_Route route ) noexc
  *
  * \return The USART peripheral's TXD pin mask.
  */
-inline auto txd_mask( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto txd_mask( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint8_t
 {
     return txd_mask( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -869,7 +883,7 @@ inline auto txd_mask( Peripheral::USART const & usart, USART_Route route ) noexc
  *
  * \return The USART peripheral's TXD pin mask.
  */
-inline auto txd_mask( Peripheral::USART const & usart ) noexcept
+inline auto txd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return txd_mask( usart, usart_route( usart ) );
 }
@@ -884,6 +898,7 @@ inline auto txd_mask( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's RXD pin PORT peripheral address.
  */
 constexpr auto rxd_port_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_port_address( usart_address, route );
 }
@@ -896,7 +911,8 @@ constexpr auto rxd_port_address( std::uintptr_t usart_address, USART_Route route
  *
  * \return The USART peripheral's RXD pin PORT peripheral.
  */
-inline auto & rxd_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto rxd_port( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::PORT &
 {
     return usart_port( usart, route );
 }
@@ -908,7 +924,7 @@ inline auto & rxd_port( Peripheral::USART const & usart, USART_Route route ) noe
  *
  * \return The USART peripheral's RXD pin PORT peripheral.
  */
-inline auto & rxd_port( Peripheral::USART const & usart ) noexcept
+inline auto rxd_port( Peripheral::USART const & usart ) noexcept -> Peripheral::PORT &
 {
     return usart_port( usart );
 }
@@ -923,6 +939,7 @@ inline auto & rxd_port( Peripheral::USART const & usart ) noexcept
  * \return The USART peripheral's RXD pin VPORT peripheral address.
  */
 constexpr auto rxd_vport_address( std::uintptr_t usart_address, USART_Route route ) noexcept
+    -> std::uintptr_t
 {
     return usart_vport_address( usart_address, route );
 }
@@ -936,7 +953,8 @@ constexpr auto rxd_vport_address( std::uintptr_t usart_address, USART_Route rout
  *
  * \return The USART peripheral's RXD pin VPORT peripheral.
  */
-inline auto & rxd_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto rxd_vport( Peripheral::USART const & usart, USART_Route route ) noexcept
+    -> Peripheral::VPORT &
 {
     return usart_vport( usart, route );
 }
@@ -949,7 +967,7 @@ inline auto & rxd_vport( Peripheral::USART const & usart, USART_Route route ) no
  *
  * \return The USART peripheral's RXD pin VPORT peripheral.
  */
-inline auto & rxd_vport( Peripheral::USART const & usart ) noexcept
+inline auto rxd_vport( Peripheral::USART const & usart ) noexcept -> Peripheral::VPORT &
 {
     return usart_vport( usart );
 }
@@ -1014,7 +1032,7 @@ constexpr auto rxd_number( std::uintptr_t usart_address, USART_Route route ) noe
  *
  * \return The USART peripheral's RXD pin number.
  */
-inline auto rxd_number( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto rxd_number( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint_fast8_t
 {
     return rxd_number( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -1026,7 +1044,7 @@ inline auto rxd_number( Peripheral::USART const & usart, USART_Route route ) noe
  *
  * \return The USART peripheral's RXD pin number.
  */
-inline auto rxd_number( Peripheral::USART const & usart ) noexcept
+inline auto rxd_number( Peripheral::USART const & usart ) noexcept -> std::uint_fast8_t
 {
     return rxd_number( usart, usart_route( usart ) );
 }
@@ -1053,7 +1071,7 @@ constexpr auto rxd_mask( std::uintptr_t usart_address, USART_Route route ) noexc
  *
  * \return The USART peripheral's RXD pin mask.
  */
-inline auto rxd_mask( Peripheral::USART const & usart, USART_Route route ) noexcept
+inline auto rxd_mask( Peripheral::USART const & usart, USART_Route route ) noexcept -> std::uint8_t
 {
     return rxd_mask( reinterpret_cast<std::uintptr_t>( &usart ), route );
 }
@@ -1065,7 +1083,7 @@ inline auto rxd_mask( Peripheral::USART const & usart, USART_Route route ) noexc
  *
  * \return The USART peripheral's RXD pin mask.
  */
-inline auto rxd_mask( Peripheral::USART const & usart ) noexcept
+inline auto rxd_mask( Peripheral::USART const & usart ) noexcept -> std::uint8_t
 {
     return rxd_mask( usart, usart_route( usart ) );
 }

--- a/include/picolibrary/microchip/megaavr0/peripheral/instance.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/instance.h
@@ -51,7 +51,7 @@ class Instance {
      *
      * \return The peripheral instance.
      */
-    static auto & instance() noexcept
+    static auto instance() noexcept -> Type &
     {
         return *reinterpret_cast<Type *>( ADDRESS );
     }

--- a/include/picolibrary/microchip/megaavr0/register.h
+++ b/include/picolibrary/microchip/megaavr0/register.h
@@ -72,7 +72,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Type expression ) noexcept
+    auto operator=( Type expression ) noexcept -> Register &
     {
         m_register = expression;
 
@@ -86,7 +86,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator&=( Type expression ) noexcept
+    auto operator&=( Type expression ) noexcept -> Register &
     {
         m_register &= expression;
 
@@ -100,7 +100,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator|=( Type expression ) noexcept
+    auto operator|=( Type expression ) noexcept -> Register &
     {
         m_register |= expression;
 
@@ -114,7 +114,7 @@ class Register {
      *
      * \return The assigned to object.
      */
-    auto & operator^=( Type expression ) noexcept
+    auto operator^=( Type expression ) noexcept -> Register &
     {
         m_register ^= expression;
 
@@ -206,7 +206,7 @@ class Protected_Register {
      *
      * \return The assigned to object.
      */
-    auto & operator=( Type expression ) noexcept
+    auto operator=( Type expression ) noexcept -> Protected_Register &
     {
         write( expression );
 
@@ -220,7 +220,7 @@ class Protected_Register {
      *
      * \return The assigned to object.
      */
-    auto & operator&=( Type expression ) noexcept
+    auto operator&=( Type expression ) noexcept -> Protected_Register &
     {
         write( m_protected_register & expression );
 
@@ -234,7 +234,7 @@ class Protected_Register {
      *
      * \return The assigned to object.
      */
-    auto & operator|=( Type expression ) noexcept
+    auto operator|=( Type expression ) noexcept -> Protected_Register &
     {
         write( m_protected_register | expression );
 
@@ -248,7 +248,7 @@ class Protected_Register {
      *
      * \return The assigned to object.
      */
-    auto & operator^=( Type expression ) noexcept
+    auto operator^=( Type expression ) noexcept -> Protected_Register &
     {
         write( m_protected_register ^ expression );
 

--- a/include/picolibrary/microchip/megaavr0/spi.h
+++ b/include/picolibrary/microchip/megaavr0/spi.h
@@ -224,7 +224,8 @@ class Fixed_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+        -> Fixed_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -269,7 +270,7 @@ class Fixed_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         initiate_exchange( data );
 
@@ -476,7 +477,8 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Fixed_Configuration_Basic_Controller && expression ) noexcept
+        -> Fixed_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -523,7 +525,7 @@ class Fixed_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         while ( not transmit_buffer_is_empty() ) {} // while
 
@@ -768,7 +770,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
          *
          * \return The configuration's CTRLA register value.
          */
-        constexpr auto ctrla() const noexcept
+        constexpr auto ctrla() const noexcept -> std::uint8_t
         {
             return m_ctrla;
         }
@@ -778,7 +780,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
          *
          * \return The configuration's CTRLB register value.
          */
-        constexpr auto ctrlb() const noexcept
+        constexpr auto ctrlb() const noexcept -> std::uint8_t
         {
             return m_ctrlb;
         }
@@ -859,7 +861,8 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+        -> Variable_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -904,7 +907,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::SPI> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         initiate_exchange( data );
 
@@ -1084,7 +1087,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
          *
          * \return The configuration's PORT.PINCTRL register INVEN field value.
          */
-        constexpr auto port_pinctrl_inven() const noexcept
+        constexpr auto port_pinctrl_inven() const noexcept -> std::uint8_t
         {
             return m_port_pinctrl_inven;
         }
@@ -1094,7 +1097,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
          *
          * \return The configuration's USART.CTRLC register value.
          */
-        constexpr auto usart_ctrlc() const noexcept
+        constexpr auto usart_ctrlc() const noexcept -> std::uint8_t
         {
             return m_usart_ctrlc;
         }
@@ -1104,7 +1107,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
          *
          * \return The configuration's USART.BAUD register value.
          */
-        constexpr auto usart_baud() const noexcept
+        constexpr auto usart_baud() const noexcept -> std::uint16_t
         {
             return m_usart_baud;
         }
@@ -1196,7 +1199,8 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+    constexpr auto operator=( Variable_Configuration_Basic_Controller && expression ) noexcept
+        -> Variable_Configuration_Basic_Controller &
     {
         if ( &expression != this ) {
             disable();
@@ -1244,7 +1248,7 @@ class Variable_Configuration_Basic_Controller<Peripheral::USART> {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) noexcept
+    auto exchange( std::uint8_t data ) noexcept -> std::uint8_t
     {
         while ( not transmit_buffer_is_empty() ) {} // while
 

--- a/include/picolibrary/testing/interactive/microchip/megaavr0/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/log.h
@@ -149,7 +149,7 @@ class Log : public Output_Stream {
      *
      * \return The log instance.
      */
-    static auto & instance() noexcept
+    static auto instance() noexcept -> Log &
     {
         expect( is_initialized(), Generic_Error::LOGIC_ERROR );
 


### PR DESCRIPTION
Resolves #661 (Replace return type deduction with explicit return types
where reasonable).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
