### PR TITLE
Display non-forced CMake cache variables to the user by default

### DIFF
--- a/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/internally_pulled_up_input_pin/state/CMakeLists.txt
@@ -67,10 +67,6 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
             "1 << 0" CACHE STRING
             "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Internally_Pulled_Up_Input_Pin state interactive test MCP23008 pin mask"
         )
-        mark_as_advanced(
-            PICOLIBRARY_MICROCHIP_MCP23008_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_MCP23008_ADDRESS
-            PICOLIBRARY_MICROCHIP_MCP23008_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_MCP23008_PIN_MASK
-        )
 
         add_executable(
             test-interactive-picolibrary-microchip-mcp23008-internally_pulled_up_input_pin-state

--- a/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/open_drain_io_pin/toggle/CMakeLists.txt
@@ -66,10 +66,6 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
             "1 << 0" CACHE STRING
             "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Open_Drain_IO_Pin toggle interactive test MCP23008 pin mask"
         )
-        mark_as_advanced(
-            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS
-            PICOLIBRARY_MICROCHIP_MCP23008_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK
-        )
 
         add_executable(
             test-interactive-picolibrary-microchip-mcp23008-open_drain_io_pin-toggle

--- a/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23008/push_pull_io_pin/toggle/CMakeLists.txt
@@ -66,10 +66,6 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
             "1 << 0" CACHE STRING
             "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23008::Push_Pull_IO_Pin toggle interactive test MCP23008 pin mask"
         )
-        mark_as_advanced(
-            PICOLIBRARY_MICROCHIP_MCP23008_PUSH_PULL_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_ADDRESS
-            PICOLIBRARY_MICROCHIP_MCP23008_PUSH_PULL_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23008_PIN_MASK
-        )
 
         add_executable(
             test-interactive-picolibrary-microchip-mcp23008-push_pull_io_pin-toggle

--- a/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/state/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23s08/internally_pulled_up_input_pin/state/CMakeLists.txt
@@ -73,10 +73,6 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
             "1 << 0" CACHE STRING
             "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23S08::Internally_Pulled_Up_Input_Pin state interactive test MCP23S08 pin mask"
         )
-        mark_as_advanced(
-            PICOLIBRARY_MICROCHIP_MCP23S08_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_MCP23S08_ADDRESS
-            PICOLIBRARY_MICROCHIP_MCP23S08_INTERNALLY_PULLED_UP_INPUT_PIN_STATE_INTERACTIVE_TEST_MCP23S08_PIN_MASK
-        )
 
         add_executable(
             test-interactive-picolibrary-microchip-mcp23s08-internally_pulled_up_input_pin-state

--- a/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23s08/open_drain_io_pin/toggle/CMakeLists.txt
@@ -72,10 +72,6 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
             "1 << 0" CACHE STRING
             "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23S08::Open_Drain_IO_Pin toggle interactive test MCP23S08 pin mask"
         )
-        mark_as_advanced(
-            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_ADDRESS
-            PICOLIBRARY_MICROCHIP_MCP23S08_OPEN_DRAIN_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_PIN_MASK
-        )
 
         add_executable(
             test-interactive-picolibrary-microchip-mcp23s08-open_drain_io_pin-toggle

--- a/test/interactive/picolibrary/microchip/mcp23s08/push_pull_io_pin/toggle/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp23s08/push_pull_io_pin/toggle/CMakeLists.txt
@@ -72,10 +72,6 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
             "1 << 0" CACHE STRING
             "picolibrary-microchip-megaavr0: picolibrary::Microchip::MCP23S08::Push_Pull_IO_Pin toggle interactive test MCP23S08 pin mask"
         )
-        mark_as_advanced(
-            PICOLIBRARY_MICROCHIP_MCP23S08_PUSH_PULL_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_ADDRESS
-            PICOLIBRARY_MICROCHIP_MCP23S08_PUSH_PULL_IO_PIN_TOGGLE_INTERACTIVE_TEST_MCP23S08_PIN_MASK
-        )
 
         add_executable(
             test-interactive-picolibrary-microchip-mcp23s08-push_pull_io_pin-toggle


### PR DESCRIPTION
Resolves #662 (Display non-forced CMake cache variables to the user by
default).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
