### PR TITLE
Add Microchip MCP3008 blocking, single sample ADC interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/microchip/mcp3008/blocking_single_sample_converter/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/mcp3008/blocking_single_sample_converter/CMakeLists.txt
@@ -13,8 +13,5 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Microchip::MCP3008 interactive tests CMake rules.
-
-# build the picolibrary::Microchip::MCP3008::Blocking_Single_Sample_Converter interactive
-# tests
-add_subdirectory( blocking_single_sample_converter )
+# Description: picolibrary::Microchip::MCP3008::Blocking_Single_Sample_Converter
+#       interactive tests CMake rules.


### PR DESCRIPTION
Resolves #667 (Add Microchip MCP3008 blocking, single sample ADC
interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
