### PR TITLE
Add Microchip megaAVR 0-series reset facilities

### DIFF
--- a/include/picolibrary/microchip/megaavr0/reset.h
+++ b/include/picolibrary/microchip/megaavr0/reset.h
@@ -25,8 +25,10 @@
 
 #include <cstdint>
 
+#include "picolibrary/error.h"
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/rstctrl.h"
+#include "picolibrary/postcondition.h"
 
 /**
  * \brief Microchip megaAVR 0-series reset facilities.
@@ -76,6 +78,8 @@ class Source {
      * \brief Assignment operator.
      *
      * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
      */
     constexpr auto operator=( Source && expression ) noexcept -> Source & = default;
 
@@ -83,6 +87,8 @@ class Source {
      * \brief Assignment operator.
      *
      * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
      */
     constexpr auto operator=( Source const & expression ) noexcept -> Source & = default;
 
@@ -184,10 +190,14 @@ inline void clear_reset_source() noexcept
 
 /**
  * \brief Initiate a software reset.
+ *
+ * \post a software reset is initiated
  */
 [[noreturn]] inline void initiate_software_reset() noexcept
 {
     Peripheral::RSTCTRL0::instance().swrr = Peripheral::RSTCTRL::SWRR::Mask::SWRE;
+    
+    ensure( false, Generic_Error::RUNTIME_ERROR );
 }
 
 } // namespace picolibrary::Microchip::megaAVR0::Reset

--- a/include/picolibrary/microchip/megaavr0/reset.h
+++ b/include/picolibrary/microchip/megaavr0/reset.h
@@ -1,0 +1,195 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Reset interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_RESET_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_RESET_H
+
+#include <cstdint>
+
+#include "picolibrary/microchip/megaavr0/peripheral.h"
+#include "picolibrary/microchip/megaavr0/peripheral/rstctrl.h"
+
+/**
+ * \brief Microchip megaAVR 0-series reset facilities.
+ */
+namespace picolibrary::Microchip::megaAVR0::Reset {
+
+/**
+ * \brief Reset source(s).
+ */
+class Source {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Source() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] rstctrl_rstfr The RSTCTRL peripheral RSTFR register value.
+     */
+    constexpr Source( std::uint8_t rstctrl_rstfr ) noexcept :
+        m_rstctrl_rstfr{ rstctrl_rstfr }
+    {
+    }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Source( Source && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Source( Source const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Source() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     */
+    constexpr auto operator=( Source && expression ) noexcept -> Source & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     */
+    constexpr auto operator=( Source const & expression ) noexcept -> Source & = default;
+
+    /**
+     * \brief Check if a power-on reset occurred.
+     *
+     * \return true if a power-on reset occur.
+     * \return false if a power-on reset did not occur.
+     */
+    constexpr auto is_power_on_reset() const noexcept -> bool
+    {
+        return m_rstctrl_rstfr & Peripheral::RSTCTRL::RSTFR::Mask::PORF;
+    }
+
+    /**
+     * \brief Check if a brown-out reset occurred.
+     *
+     * \return true if a brown-out reset did occur.
+     * \return false if a brown-out reset did not occur.
+     */
+    constexpr auto is_brown_out_reset() const noexcept -> bool
+    {
+        return m_rstctrl_rstfr & Peripheral::RSTCTRL::RSTFR::Mask::BORF;
+    }
+
+    /**
+     * \brief Check if an external reset occurred.
+     *
+     * \return true if an external reset did occur.
+     * \return false if an external reset did not occur.
+     */
+    constexpr auto is_external_reset() const noexcept -> bool
+    {
+        return m_rstctrl_rstfr & Peripheral::RSTCTRL::RSTFR::Mask::EXTRF;
+    }
+
+    /**
+     * \brief Check if a watchdog reset occurred.
+     *
+     * \return true if a watchdog reset did occur.
+     * \return false if a watchdog reset did not occur.
+     */
+    constexpr auto is_watchdog_reset() const noexcept -> bool
+    {
+        return m_rstctrl_rstfr & Peripheral::RSTCTRL::RSTFR::Mask::WDRF;
+    }
+
+    /**
+     * \brief Check if a software reset occurred.
+     *
+     * \return true if a software reset did occur.
+     * \return false if a software reset did not occur.
+     */
+    constexpr auto is_software_reset() const noexcept -> bool
+    {
+        return m_rstctrl_rstfr & Peripheral::RSTCTRL::RSTFR::Mask::SWRF;
+    }
+
+    /**
+     * \brief Check if a UPDI reset occurred.
+     *
+     * \return true if a UPDI reset did occur.
+     * \return false if a UPDI reset did not occur.
+     */
+    constexpr auto is_updi_reset() const noexcept -> bool
+    {
+        return m_rstctrl_rstfr & Peripheral::RSTCTRL::RSTFR::Mask::UPDIRF;
+    }
+
+  private:
+    /**
+     * \brief The RSTCTRL peripheral RSTFR register value.
+     */
+    std::uint8_t m_rstctrl_rstfr{ 0x00 };
+};
+
+/**
+ * \brief Get the reset source(s).
+ *
+ * \return The reset source(s).
+ */
+inline auto source() noexcept -> Source
+{
+    return Source{ Peripheral::RSTCTRL0::instance().rstfr };
+}
+
+/**
+ * \brief Clear the reset source(s).
+ */
+inline void clear_reset_source() noexcept
+{
+    Peripheral::RSTCTRL0::instance().rstfr = Peripheral::RSTCTRL::RSTFR::Mask::UPDIRF
+                                             | Peripheral::RSTCTRL::RSTFR::Mask::SWRF
+                                             | Peripheral::RSTCTRL::RSTFR::Mask::WDRF
+                                             | Peripheral::RSTCTRL::RSTFR::Mask::EXTRF
+                                             | Peripheral::RSTCTRL::RSTFR::Mask::BORF
+                                             | Peripheral::RSTCTRL::RSTFR::Mask::PORF;
+}
+
+/**
+ * \brief Initiate a software reset.
+ */
+[[noreturn]] inline void initiate_software_reset() noexcept
+{
+    Peripheral::RSTCTRL0::instance().swrr = Peripheral::RSTCTRL::SWRR::Mask::SWRE;
+}
+
+} // namespace picolibrary::Microchip::megaAVR0::Reset
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_RESET_H

--- a/include/picolibrary/microchip/megaavr0/reset.h
+++ b/include/picolibrary/microchip/megaavr0/reset.h
@@ -196,7 +196,7 @@ inline void clear_reset_source() noexcept
 [[noreturn]] inline void initiate_software_reset() noexcept
 {
     Peripheral::RSTCTRL0::instance().swrr = Peripheral::RSTCTRL::SWRR::Mask::SWRE;
-    
+
     ensure( false, Generic_Error::RUNTIME_ERROR );
 }
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -47,6 +47,7 @@ set(
     "picolibrary/microchip/megaavr0/peripheral/vport.cc"
     "picolibrary/microchip/megaavr0/peripheral/wdt.cc"
     "picolibrary/microchip/megaavr0/register.cc"
+    "picolibrary/microchip/megaavr0/reset.cc"
     "picolibrary/microchip/megaavr0/spi.cc"
     "picolibrary/microchip/megaavr0/watchdog_timer.cc"
 )

--- a/source/picolibrary/microchip/megaavr0/reset.cc
+++ b/source/picolibrary/microchip/megaavr0/reset.cc
@@ -1,0 +1,23 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Reset implementation.
+ */
+
+#include "picolibrary/microchip/megaavr0/reset.h"


### PR DESCRIPTION
Resolves #681 (Add Microchip megaAVR 0-series reset facilities).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
