### PR TITLE
Add Microchip megaAVR 0-series device info interactive testing facilities namespace

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
@@ -1,0 +1,32 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info interface.
+ */
+
+#ifndef PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H
+#define PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H
+
+/**
+ * \brief Microchip megaAVR 0-series device info interactive testing facilities.
+ */
+namespace picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info {
+} // namespace picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info
+
+#endif // PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -62,6 +62,7 @@ if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
         APPEND PICOLIBRARY_MICROCHIP_MEGAAVR0_SOURCE_FILES
         "picolibrary/testing/interactive/microchip/megaavr0.cc"
         "picolibrary/testing/interactive/microchip/megaavr0/clock.cc"
+        "picolibrary/testing/interactive/microchip/megaavr0/device_info.cc"
         "picolibrary/testing/interactive/microchip/megaavr0/log.cc"
     )
 endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )

--- a/source/picolibrary/testing/interactive/microchip/megaavr0/device_info.cc
+++ b/source/picolibrary/testing/interactive/microchip/megaavr0/device_info.cc
@@ -1,0 +1,24 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info
+ *        implementation.
+ */
+
+#include "picolibrary/testing/interactive/microchip/megaavr0/device_info.h"


### PR DESCRIPTION
Resolves #690 (Add Microchip megaAVR 0-series device info interactive
testing facilities namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
