### PR TITLE
Add Microchip megaAVR 0-series device info print interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
@@ -23,10 +23,32 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H
 
+#include "picolibrary/microchip/megaavr0/device_info.h"
+#include "picolibrary/precondition.h"
+#include "picolibrary/stream.h"
+
 /**
  * \brief Microchip megaAVR 0-series device info interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info {
+
+/**
+ * \brief Print interactive test helper.
+ *
+ * \param[in] stream The output stream to write the device info to.
+ *
+ * \pre writing to the stream succeeds
+ */
+inline void print( Output_Stream & stream ) noexcept
+{
+    auto const result = stream.print(
+        "{} (revision {}), serial number {}\n",
+        ::picolibrary::Microchip::megaAVR0::Device_Info::device_type(),
+        ::picolibrary::Microchip::megaAVR0::Device_Info::device_revision(),
+        ::picolibrary::Microchip::megaAVR0::Device_Info::device_serial_number() );
+    expect( not result.is_error(), result.error() );
+}
+
 } // namespace picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info
 
 #endif // PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H


### PR DESCRIPTION
Resolves #692 (Add Microchip megaAVR 0-series device info print
interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
