### PR TITLE
Add Microchip megaAVR 0-series device info print interactive test

### DIFF
--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/CMakeLists.txt
@@ -85,6 +85,7 @@ include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp23s08/push_pull_io_pin/toggle/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/mcp3008/blocking_single_sample_converter/sample/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/asynchronous_serial/transmitter/hello_world/CMakeLists.txt" )
+include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/internally_pulled_up_input_pin/state/CMakeLists.txt" )
 include( "${CMAKE_CURRENT_LIST_DIR}/test/interactive/picolibrary/microchip/megaavr0/gpio/open_drain_io_pin/toggle/CMakeLists.txt" )

--- a/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+++ b/configuration/testing-interactive-atmega4809-arduino-nano-every/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
@@ -13,8 +13,11 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Microchip::megaAVR0::Device_Info interactive tests CMake
-#       rules.
+# Description: picolibrary-microchip-megaavr0 ATmega4809 Arduino Nano Every
+#       picolibrary::Microchip::megaAVR0::Device_Info print interactive test
+#       configuration.
 
-# build the picolibrary::Microchip::megaAVR0::Device_Info print interactive test
-add_subdirectory( print )
+set( PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST ON CACHE BOOL "" FORCE )
+mark_as_advanced(
+    PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST
+)

--- a/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
@@ -1,0 +1,48 @@
+# picolibrary-microchip-megaavr0
+#
+# Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+# picolibrary-microchip-megaavr0 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Description: picolibrary::Microchip::megaAVR0::Device_Info print interactive test
+#       CMake rules.
+
+# build the picolibrary::Microchip::megaAVR0::Device_Info print interactive test
+if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
+    option(
+        PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST
+        "picolibrary-microchip-megaavr0: enable the picolibrary::Microchip::megaAVR0::Device_Info print interactive test"
+        OFF
+    )
+
+    if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST} )
+        add_executable(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            main.cc
+        )
+        target_link_libraries(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            picolibrary
+            picolibrary-microchip-megaavr0
+            picolibrary-microchip-megaavr0-testing-interactive-fatal_error
+        )
+        add_avrdude_programming_targets(
+            test-interactive-picolibrary-microchip-megaavr0-device_info-print
+            "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_RESET}"
+            CONFIGURATION_FILE "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_CONFIGURATION_FILE}"
+            PORT               "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PORT}"
+            PROGRAM_FLASH      "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_PROGRAM_FLASH}"
+            VERBOSITY          "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERBOSITY}"
+            VERIFY_FLASH       "${PICOLIBRARY_MICROCHIP_MEGAAVR0_AVRDUDE_VERIFY_FLASH}"
+        )
+    endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_DEVICE_INFO_ENABLE_PRINT_INTERACTIVE_TEST} )
+endif( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
+++ b/test/interactive/picolibrary/microchip/megaavr0/device_info/print/CMakeLists.txt
@@ -13,8 +13,8 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Microchip::megaAVR0::Device_Info print interactive test
-#       CMake rules.
+# Description: picolibrary::Microchip::megaAVR0::Device_Info print interactive test CMake
+#       rules.
 
 # build the picolibrary::Microchip::megaAVR0::Device_Info print interactive test
 if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )

--- a/test/interactive/picolibrary/microchip/megaavr0/device_info/print/main.cc
+++ b/test/interactive/picolibrary/microchip/megaavr0/device_info/print/main.cc
@@ -1,0 +1,50 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2022, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Device_Info print interactive test program.
+ */
+
+#include "picolibrary/testing/interactive/microchip/megaavr0/clock.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/device_info.h"
+#include "picolibrary/testing/interactive/microchip/megaavr0/log.h"
+
+namespace {
+
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log;
+using ::picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info::print;
+
+} // namespace
+
+/**
+ * \brief Execute the picolibrary::Microchip::megaAVR0::Device_Info print interactive
+ *        test.
+ *
+ * \return N/A
+ */
+int main() noexcept
+{
+    configure_clock();
+
+    Log::initialize();
+
+    print( Log::instance() );
+
+    for ( ;; ) {} // for
+}


### PR DESCRIPTION
Resolves #693 (Add Microchip megaAVR 0-series device info print
interactive test).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
