### PR TITLE
Fix missing Microchip megaAVR 0-series device info print interactive test helper output stream flush

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
@@ -41,12 +41,19 @@ namespace picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info {
  */
 inline void print( Output_Stream & stream ) noexcept
 {
-    auto const result = stream.print(
-        "{} (revision {}), serial number {}\n",
-        ::picolibrary::Microchip::megaAVR0::Device_Info::device_type(),
-        ::picolibrary::Microchip::megaAVR0::Device_Info::device_revision(),
-        ::picolibrary::Microchip::megaAVR0::Device_Info::device_serial_number() );
-    expect( not result.is_error(), result.error() );
+    {
+        auto result = stream.print(
+            "{} (revision {}), serial number {}\n",
+            ::picolibrary::Microchip::megaAVR0::Device_Info::device_type(),
+            ::picolibrary::Microchip::megaAVR0::Device_Info::device_revision(),
+            ::picolibrary::Microchip::megaAVR0::Device_Info::device_serial_number() );
+        expect( not result.is_error(), result.error() );
+    }
+
+    {
+        auto result = stream.flush();
+        expect( not result.is_error(), result.error() );
+    }
 }
 
 } // namespace picolibrary::Testing::Interactive::Microchip::megaAVR0::Device_Info


### PR DESCRIPTION
Resolves #698 (Fix missing Microchip megaAVR 0-series device info print
interactive test helper output stream flush).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
