### PR TITLE
Fix inconsistent use of scope resolution operators in documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,22 +34,22 @@ picolibrary-microchip-megaavr0 supports the following project configuration opti
       `PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING` is `ON`
         - `PICOLIBRARY_MICROCHIP_MEGAAVR0_TESTING_INTERACTIVE_CONFIGURE_CLOCK_CLOCK_PRESCALER_VALUE`
           (optional):
-          `picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
+          `::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
           clock prescaler value
         - `PICOLIBRARY_MICROCHIP_MEGAAVR0_TESTING_INTERACTIVE_CONFIGURE_CLOCK_CLOCK_PRESCALER_CONFIGURATION`
           (optional):
-          `picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
+          `::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
           clock prescaler configuration
         - `PICOLIBRARY_MICROCHIP_MEGAAVR0_TESTING_INTERACTIVE_LOG_USART` (optional):
-          `picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` USART
+          `::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` USART
         - `PICOLIBRARY_MICROCHIP_MEGAAVR0_TESTING_INTERACTIVE_LOG_USART_ROUTE` (optional):
-          `picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` USART route
+          `::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` USART route
         - `PICOLIBRARY_MICROCHIP_MEGAAVR0_TESTING_INTERACTIVE_LOG_USART_CLOCK_GENERATOR_OPERATING_SPEED`
-          (optional): `picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` USART
-          clock generator operating speed
+          (optional): `::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log`
+          USART clock generator operating speed
         - `PICOLIBRARY_MICROCHIP_MEGAAVR0_TESTING_INTERACTIVE_LOG_USART_CLOCK_GENERATOR_SCALING_FACTOR`
-          (optional): `picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` USART
-          clock generator scaling factor
+          (optional): `::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log`
+          USART clock generator scaling factor
 - `PICOLIBRARY_MICROCHIP_MEGAAVR0_USE_PARENT_PROJECT_BUILD_FLAGS` (defaults to `ON`): use
   parent project's build flags
     - The following project configuration options are available if


### PR DESCRIPTION
Resolves #750 (Fix inconsistent use of scope resolution operators in documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
