### PR TITLE
Update precondition expectation checks on execution paths that always fail

### DIFF
--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/spi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/spi.h
@@ -66,9 +66,7 @@ inline auto spi_route( Peripheral::SPI const & spi ) noexcept -> SPI_Route
                 portmux.twispiroutea & Peripheral::PORTMUX::TWISPIROUTEA::Mask::SPI0 );
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return SPI_Route::NONE; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -89,7 +87,7 @@ inline void set_spi_route( Peripheral::SPI const & spi, SPI_Route route ) noexce
             return;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -117,9 +115,7 @@ constexpr auto spi_port_address( std::uintptr_t spi_address, SPI_Route route ) n
             break;
     };
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -173,9 +169,7 @@ constexpr auto spi_vport_address( std::uintptr_t spi_address, SPI_Route route ) 
             break;
     };
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -307,9 +301,7 @@ constexpr auto ss_number( std::uintptr_t spi_address, SPI_Route route ) noexcept
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -479,9 +471,7 @@ constexpr auto sck_number( std::uintptr_t spi_address, SPI_Route route ) noexcep
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -651,9 +641,7 @@ constexpr auto mosi_number( std::uintptr_t spi_address, SPI_Route route ) noexce
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -823,9 +811,7 @@ constexpr auto miso_number( std::uintptr_t spi_address, SPI_Route route ) noexce
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/twi.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/twi.h
@@ -62,9 +62,7 @@ inline auto twi_route( Peripheral::TWI const & twi ) noexcept -> TWI_Route
                 portmux.twispiroutea & Peripheral::PORTMUX::TWISPIROUTEA::Mask::TWI0 );
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return TWI_Route::DEFAULT; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -85,7 +83,7 @@ inline void set_twi_route( Peripheral::TWI const & twi, TWI_Route route ) noexce
             return;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -109,9 +107,7 @@ constexpr auto scl_number( std::uintptr_t twi_address, TWI_Route route ) noexcep
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -199,9 +195,7 @@ constexpr auto sda_number( std::uintptr_t twi_address, TWI_Route route ) noexcep
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -290,9 +284,7 @@ constexpr auto twi_controller_port_address( std::uintptr_t twi_address, TWI_Rout
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -346,9 +338,7 @@ constexpr auto twi_controller_vport_address( std::uintptr_t twi_address, TWI_Rou
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -734,9 +724,7 @@ constexpr auto twi_device_port_address( std::uintptr_t twi_address, TWI_Route ro
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -788,9 +776,7 @@ constexpr auto twi_device_vport_address( std::uintptr_t twi_address, TWI_Route r
             break;
     } // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**

--- a/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
+++ b/include/picolibrary/microchip/megaavr0/multiplexed_signals/usart.h
@@ -80,9 +80,7 @@ inline auto usart_route( Peripheral::USART const & usart ) noexcept -> USART_Rou
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     }  // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return USART_Route::NONE; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -123,7 +121,7 @@ inline void set_usart_route( Peripheral::USART const & usart, USART_Route route 
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     }  // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -174,9 +172,7 @@ constexpr auto usart_port_address( std::uintptr_t usart_address, USART_Route rou
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     };
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -254,9 +250,7 @@ constexpr auto usart_vport_address( std::uintptr_t usart_address, USART_Route ro
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     };
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -417,9 +411,7 @@ constexpr auto xck_number( std::uintptr_t usart_address, USART_Route route ) noe
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     }  // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -619,9 +611,7 @@ constexpr auto xdir_number( std::uintptr_t usart_address, USART_Route route ) no
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     }  // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -819,9 +809,7 @@ constexpr auto txd_number( std::uintptr_t usart_address, USART_Route route ) noe
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     }  // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**
@@ -1019,9 +1007,7 @@ constexpr auto rxd_number( std::uintptr_t usart_address, USART_Route route ) noe
 #endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
     }  // switch
 
-    expect( false, Generic_Error::INVALID_ARGUMENT );
-
-    return 0; // unreachable
+    expect( Generic_Error::INVALID_ARGUMENT );
 }
 
 /**


### PR DESCRIPTION
Resolves #756 (Update precondition expectation checks on execution paths that always fail).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
