### PR TITLE
Update postcondition expectation checks on execution paths that always fail

### DIFF
--- a/include/picolibrary/microchip/megaavr0/reset.h
+++ b/include/picolibrary/microchip/megaavr0/reset.h
@@ -197,7 +197,7 @@ inline void clear_reset_source() noexcept
 {
     Peripheral::RSTCTRL0::instance().swrr = Peripheral::RSTCTRL::SWRR::Mask::SWRE;
 
-    ensure( false, Generic_Error::RUNTIME_ERROR );
+    ensure( Generic_Error::RUNTIME_ERROR );
 }
 
 } // namespace picolibrary::Microchip::megaAVR0::Reset


### PR DESCRIPTION
Resolves #757 (Update postcondition expectation checks on execution paths that always fail).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
