### PR TITLE
Remove unused format specification parse functions from output formatters

### DIFF
--- a/include/picolibrary/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/microchip/megaavr0/device_info.h
@@ -478,21 +478,6 @@ class Output_Formatter<Microchip::megaAVR0::Device_Info::Device_Type> {
         -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the
-     *        picolibrary::Microchip::megaAVR0::Device_Info::Device_Type to be formatted.
-     *
-     * \param[in] format The format specification for the
-     *            picolibrary::Microchip::megaAVR0::Device_Info::Device_Type to be
-     *            formatted.
-     *
-     * \return format
-     */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
-
-    /**
      * \brief Write the formatted
      *        picolibrary::Microchip::megaAVR0::Device_Info::Device_Type to the stream.
      *
@@ -628,22 +613,6 @@ class Output_Formatter<Microchip::megaAVR0::Device_Info::Device_Revision> {
         -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the
-     *        picolibrary::Microchip::megaAVR0::Device_Info::Device_Revision to be
-     *        formatted.
-     *
-     * \param[in] format The format specification for the
-     *            picolibrary::Microchip::megaAVR0::Device_Info::Device_Revision to be
-     *            formatted.
-     *
-     * \return format
-     */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
-
-    /**
      * \brief Write the formatted
      *        picolibrary::Microchip::megaAVR0::Device_Info::Device_Revision to the
      *        stream.
@@ -742,22 +711,6 @@ class Output_Formatter<Microchip::megaAVR0::Device_Info::Device_Serial_Number> {
      */
     constexpr auto operator   =( Output_Formatter const & expression ) noexcept
         -> Output_Formatter & = default;
-
-    /**
-     * \brief Parse the format specification for the
-     *        picolibrary::Microchip::megaAVR0::Device_Info::Device_Serial_Number to be
-     *        formatted.
-     *
-     * \param[in] format The format specification for the
-     *            picolibrary::Microchip::megaAVR0::Device_Info::Device_Serial_Number to
-     *            be formatted.
-     *
-     * \return format
-     */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
 
     /**
      * \brief Write the formatted


### PR DESCRIPTION
Resolves #772 (Remove unused format specification parse functions from output formatters).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
