### PR TITLE
Move string literals to ROM

### DIFF
--- a/include/picolibrary/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/microchip/megaavr0/device_info.h
@@ -532,7 +532,7 @@ class Output_Formatter<Microchip::megaAVR0::Device_Info::Device_Type> {
      * \return The picolibrary::Microchip::megaAVR0::Device_Info::Device_Type converted to
      *         a null-terminated string.
      */
-    static constexpr auto to_string( Microchip::megaAVR0::Device_Info::Device_Type const & device_type ) noexcept
+    static auto to_string( Microchip::megaAVR0::Device_Info::Device_Type const & device_type ) noexcept
         -> ROM::String
     {
         switch ( device_type ) {

--- a/include/picolibrary/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/microchip/megaavr0/device_info.h
@@ -33,6 +33,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/sigrow.h"
 #include "picolibrary/result.h"
+#include "picolibrary/rom.h"
 #include "picolibrary/stream.h"
 
 /**
@@ -517,7 +518,7 @@ class Output_Formatter<Microchip::megaAVR0::Device_Info::Device_Type> {
 
         stream.put( device_type_as_string );
 
-        return std::strlen( device_type_as_string );
+        return ROM::length( device_type_as_string );
     }
 
   private:
@@ -532,28 +533,28 @@ class Output_Formatter<Microchip::megaAVR0::Device_Info::Device_Type> {
      *         a null-terminated string.
      */
     static constexpr auto to_string( Microchip::megaAVR0::Device_Info::Device_Type const & device_type ) noexcept
-        -> char const *
+        -> ROM::String
     {
         switch ( device_type ) {
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA808:
-                return "ATmega808";
+                return PICOLIBRARY_ROM_STRING( "ATmega808" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA809:
-                return "ATmega809";
+                return PICOLIBRARY_ROM_STRING( "ATmega809" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA1608:
-                return "ATmega1608";
+                return PICOLIBRARY_ROM_STRING( "ATmega1608" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA1609:
-                return "ATmega1609";
+                return PICOLIBRARY_ROM_STRING( "ATmega1609" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA3208:
-                return "ATmega3208";
+                return PICOLIBRARY_ROM_STRING( "ATmega3208" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA3209:
-                return "ATmega3209";
+                return PICOLIBRARY_ROM_STRING( "ATmega3209" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA4808:
-                return "ATmega4808";
+                return PICOLIBRARY_ROM_STRING( "ATmega4808" );
             case Microchip::megaAVR0::Device_Info::Device_Type::ATMEGA4809:
-                return "ATmega4809";
+                return PICOLIBRARY_ROM_STRING( "ATmega4809" );
         } // switch
 
-        return "UNKNOWN";
+        return PICOLIBRARY_ROM_STRING( "UNKNOWN" );
     }
 };
 

--- a/include/picolibrary/microchip/megaavr0/version.h
+++ b/include/picolibrary/microchip/megaavr0/version.h
@@ -23,6 +23,8 @@
 #ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_VERSION_H
 #define PICOLIBRARY_MICROCHIP_MEGAAVR0_VERSION_H
 
+#include "picolibrary/rom.h"
+
 namespace picolibrary::Microchip::megaAVR0 {
 
 /**
@@ -30,7 +32,7 @@ namespace picolibrary::Microchip::megaAVR0 {
  *
  * \return The library version.
  */
-auto version() noexcept -> char const *;
+auto version() noexcept -> ROM::String;
 
 } // namespace picolibrary::Microchip::megaAVR0
 

--- a/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/device_info.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MEGAAVR0_DEVICE_INFO_H
 
 #include "picolibrary/microchip/megaavr0/device_info.h"
+#include "picolibrary/rom.h"
 #include "picolibrary/stream.h"
 
 /**
@@ -40,9 +41,9 @@ inline void print( Reliable_Output_Stream & stream ) noexcept
 {
     stream.print(
         ::picolibrary::Microchip::megaAVR0::Device_Info::device_type(),
-        " (revision ",
+        PICOLIBRARY_ROM_STRING( " (revision " ),
         ::picolibrary::Microchip::megaAVR0::Device_Info::device_revision(),
-        "), serial number ",
+        PICOLIBRARY_ROM_STRING( "), serial number " ),
         ::picolibrary::Microchip::megaAVR0::Device_Info::device_serial_number(),
         '\n' );
 

--- a/include/picolibrary/testing/interactive/microchip/megaavr0/log.h
+++ b/include/picolibrary/testing/interactive/microchip/megaavr0/log.h
@@ -31,6 +31,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral.h"
 #include "picolibrary/microchip/megaavr0/peripheral/usart.h"
 #include "picolibrary/precondition.h"
+#include "picolibrary/rom.h"
 #include "picolibrary/stream.h"
 #include "picolibrary/utility.h"
 
@@ -133,9 +134,9 @@ class Log : public Reliable_Output_Stream {
     static void report_fatal_error( Error_Code const & error ) noexcept
     {
         if ( is_initialized() ) {
-            transmit( "fatal error: " );
+            transmit( PICOLIBRARY_ROM_STRING( "fatal error: " ) );
             transmit( error.category().name() );
-            transmit( "::" );
+            transmit( PICOLIBRARY_ROM_STRING( "::" ) );
             transmit( error.description() );
             transmit( '\n' );
         } // if

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -132,6 +132,10 @@ target_include_directories(
     picolibrary-microchip-megaavr0-version
     PUBLIC "${PROJECT_SOURCE_DIR}/include"
 )
+target_link_libraries(
+    picolibrary-microchip-megaavr0-version
+    picolibrary
+)
 
 if( ${PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING} )
     add_library(

--- a/source/picolibrary/microchip/megaavr0/version.cc.in
+++ b/source/picolibrary/microchip/megaavr0/version.cc.in
@@ -21,12 +21,13 @@
  */
 
 #include "picolibrary/microchip/megaavr0/version.h"
+#include "picolibrary/rom.h"
 
 namespace picolibrary::Microchip::megaAVR0 {
 
-auto version() noexcept -> char const *
+auto version() noexcept -> ROM::String
 {
-    return "@PICOLIBRARY_MICROCHIP_MEGAAVR0_VERSION@";
+    return PICOLIBRARY_ROM_STRING( "@PICOLIBRARY_MICROCHIP_MEGAAVR0_VERSION@" );
 }
 
 } // namespace picolibrary::Microchip::megaAVR0


### PR DESCRIPTION
Resolves #781 (Move string literals to ROM).

These changes are not necessary from a purely practical perspective since avr-gcc automatically places string literals in ROM when using Microchip megaAVR 0-series microcontrollers. However, these changes do ensure that picolibrary and its HILs have a consistent code style.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
