### PR TITLE
Relocate Microchip megaAVR 0-series interactive testing clock configuration utility documentation

### DIFF
--- a/docs/clock.md
+++ b/docs/clock.md
@@ -12,7 +12,6 @@ header/source file pair.
 1. [Internal 32.768 kHz Ultra Low-Power Oscillator](#internal-32768-khz-ultra-low-power-oscillator)
 1. [External 32.768 kHz Crystal Oscillator](#external-32768-khz-crystal-oscillator)
 1. [External Clock](#external-clock)
-1. [Interactive Testing Clock Configuration](#interactive-testing-clock-configuration)
 
 ## Source
 The following Microchip megaAVR 0-series clock source operations are supported:
@@ -122,12 +121,3 @@ are supported:
 The following Microchip megaAVR 0-series external clock operations are supported:
 - To check if the external clock is stable, use the
   `::picolibrary::Microchip::megaAVR0::Clock::external_clock_stable()` member function.
-
-## Interactive Testing Clock Configuration
-The `::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
-interactive testing clock configuration utilities are available if the
-`PICOLIBRARY_MICROCHIP_MEGAAVR0_ENABLE_INTERACTIVE_TESTING` project configuration option
-is `ON`.
-The utilities are defined in the
-[`include/picolibrary/testing/interactive/microchip/megaavr0/clock.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/testing/interactive/microchip/megaavr0/clock.h)/[`source/picolibrary/testing/interactive/microchip/megaavr0/clock.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/testing/interactive/microchip/megaavr0/clock.cc)
-header/source file pair.

--- a/docs/interactive_testing_utilities.md
+++ b/docs/interactive_testing_utilities.md
@@ -5,6 +5,7 @@ is `ON`.
 
 ## Table of Contents
 1. [Fatal Error Trap](#fatal-error-trap)
+1. [Clock Configuration](#clock-configuration)
 1. [Log](#log)
 
 ## Fatal Error Trap
@@ -16,6 +17,15 @@ source file.
 The `picolibrary-microchip-megaavr0` static library does not include this implementation.
 To use this implementation, link with the
 `picolibrary-microchip-megaavr0-testing-interactive-fatal_error` static library.
+
+## Clock Configuration
+The `::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
+functions configure the Microchip megaAVR 0-series clock to use the internal 16/20 MHz
+oscillator with the desired clock prescaler settings.
+The `::picolibrary::Testing::Interactive::Microchip::megaAVR0::configure_clock()`
+functions are defined in the
+[`include/picolibrary/testing/interactive/microchip/megaavr0/clock.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/testing/interactive/microchip/megaavr0/clock.h)/[`source/picolibrary/testing/interactive/microchip/megaavr0/clock.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/testing/interactive/microchip/megaavr0/clock.cc)
+header/source file pair.
 
 ## Log
 The `::picolibrary::Testing::Interactive::Microchip::megaAVR0::Log` class is a reliable


### PR DESCRIPTION
Resolves #826 (Relocate Microchip megaAVR 0-series interactive testing clock configuration utility documentation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
