### PR TITLE
Fix Microchip megaAVR 0-series USART peripheral documentation

### DIFF
--- a/docs/peripheral.md
+++ b/docs/peripheral.md
@@ -94,7 +94,7 @@ header/source file pair.
 
 ### USART
 The `::picolibrary::Microchip::megaAVR0::Peripheral::USART` class defines the layout of
-the Microchip megaAVR 0-series USART peripheral.
+the Microchip megaAVR 0-series USART peripheral and information about its registers.
 The `::picolibrary::Microchip::megaAVR0::Peripheral::USART` class is defined in the
 [`include/picolibrary/microchip/megaavr0/peripheral/usart.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/usart.h)/[`source/picolibrary/microchip/megaavr0/peripheral/usart.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/usart.cc)
 header/source file pair.


### PR DESCRIPTION
Resolves #835 (Fix Microchip megaAVR 0-series USART peripheral documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
