### PR TITLE
Fix Microchip megaAVR 0-series peripheral instances documentation typo

### DIFF
--- a/docs/peripheral.md
+++ b/docs/peripheral.md
@@ -115,7 +115,7 @@ header/source file pair.
 
 ## Peripheral Instances
 The `::picolibrary::Microchip::megaAVR0::Peripheral::Instance` template class is used to
-define Microchip megaAVR0 peripheral instances.
+define Microchip megaAVR 0-series peripheral instances.
 The `::picolibrary::Microchip::megaAVR0::Peripheral::Instance` template class is defined
 in the
 [`include/picolibrary/microchip/megaavr0/peripheral/instance.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/instance.h)/[`source/picolibrary/microchip/megaavr0/peripheral/instance.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/instance.cc)


### PR DESCRIPTION
Resolves #836 (Fix Microchip megaAVR 0-series peripheral instances documentation typo).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
