### PR TITLE
Add Microchip megaAVR 0-series SLPCTRL peripheral

### DIFF
--- a/docs/peripheral.md
+++ b/docs/peripheral.md
@@ -7,6 +7,7 @@
     1. [PORTMUX](#portmux)
     1. [RSTCTRL](#rstctrl)
     1. [SIGROW](#sigrow)
+    1. [SLPCTRL](#slpctrl)
     1. [SPI](#spi)
     1. [SYSCFG](#syscfg)
     1. [TWI](#twi)
@@ -69,6 +70,13 @@ The `::picolibrary::Microchip::megaAVR0::Peripheral::SIGROW` class defines the l
 the Microchip megaAVR 0-series SIGROW peripheral and information about its registers.
 The `::picolibrary::Microchip::megaAVR0::Peripheral::SIGROW` class is defined in the
 [`include/picolibrary/microchip/megaavr0/peripheral/sigrow.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/sigrow.h)/[`source/picolibrary/microchip/megaavr0/peripheral/sigrow.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/sigrow.cc)
+header/source file pair.
+
+### SLPCTRL
+The `::picolibrary::Microchip::megaAVR0::Peripheral::SLPCTRL` class defines the layout of
+the Microchip megaAVR 0-series SLPCTRL peripheral and information about its registers.
+The `::picolibrary::Microchip::megaAVR0::Peripheral::SLPCTRL` class is defined in the
+[`include/picolibrary/microchip/megaavr0/peripheral/slpctrl.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/slpctrl.h)/[`source/picolibrary/microchip/megaavr0/peripheral/slpctrl.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/slpctrl.cc)
 header/source file pair.
 
 ### SPI
@@ -142,6 +150,7 @@ The following peripheral instances are defined (listed alphabetically):
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTMUX0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::RSTCTRL0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::SIGROW0`
+- `::picolibrary::Microchip::megaAVR0::Peripheral::SLPCTRL0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::SPI0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::SYSCFG0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::TWI0`

--- a/include/picolibrary/microchip/megaavr0/peripheral.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral.h
@@ -29,6 +29,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/portmux.h"
 #include "picolibrary/microchip/megaavr0/peripheral/rstctrl.h"
 #include "picolibrary/microchip/megaavr0/peripheral/sigrow.h"
+#include "picolibrary/microchip/megaavr0/peripheral/slpctrl.h"
 #include "picolibrary/microchip/megaavr0/peripheral/spi.h"
 #include "picolibrary/microchip/megaavr0/peripheral/syscfg.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
@@ -81,6 +82,11 @@ using VPORTF = Instance<VPORT, 0x0014>;
  * \brief RSTCTRL0.
  */
 using RSTCTRL0 = Instance<RSTCTRL, 0x0040>;
+
+/**
+ * \brief SLPCTRL0.
+ */
+using SLPCTRL0 = Instance<SLPCTRL, 0x0050>;
 
 /**
  * \brief CLKCTRL0.

--- a/include/picolibrary/microchip/megaavr0/peripheral/slpctrl.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/slpctrl.h
@@ -1,0 +1,118 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::SLPCTRL interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_SLPCTRL_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_SLPCTRL_H
+
+#include <cstdint>
+
+#include "picolibrary/bit_manipulation.h"
+#include "picolibrary/microchip/megaavr0/register.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+/**
+ * \brief Microchip megaAVR 0-series Sleep Controller (SLPCTRL) peripheral.
+ */
+class SLPCTRL {
+  public:
+    /**
+     * \brief Control A (CTRLA) register.
+     *
+     * This register has the following fields:
+     * - Sleep Enable (SEN)
+     * - Sleep Mode (SMODE)
+     */
+    class CTRLA : public Register<std::uint8_t> {
+      public:
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto SEN       = std::uint_fast8_t{ 1 }; ///< SEN.
+            static constexpr auto SMODE     = std::uint_fast8_t{ 2 }; ///< SMODE.
+            static constexpr auto RESERVED3 = std::uint_fast8_t{ 5 }; ///< RESERVED3.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto SEN   = std::uint_fast8_t{};                  ///< SEN.
+            static constexpr auto SMODE = std::uint_fast8_t{ SEN + Size::SEN }; ///< SMODE.
+            static constexpr auto RESERVED3 = std::uint_fast8_t{ SMODE + Size::SMODE }; ///< RESERVED3.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto SEN = mask<std::uint8_t>( Size::SEN, Bit::SEN ); ///< SEN.
+            static constexpr auto SMODE = mask<std::uint8_t>( Size::SMODE, Bit::SMODE ); ///< SMODE.
+            static constexpr auto RESERVED3 = mask<std::uint8_t>( Size::RESERVED3, Bit::RESERVED3 ); ///< RESERVED3.
+        };
+
+        /**
+         * \brief SMODE.
+         */
+        enum SMODE : std::uint8_t {
+            SMODE_IDLE    = 0x0 << Bit::SMODE, ///< Idle sleep mode.
+            SMODE_STANDBY = 0x1 << Bit::SMODE, ///< Standby sleep mode.
+            SMODE_PDOWN   = 0x2 << Bit::SMODE, ///< Power-down sleep mode.
+        };
+
+        CTRLA() = delete;
+
+        CTRLA( CTRLA && ) = delete;
+
+        CTRLA( CTRLA const & ) = delete;
+
+        ~CTRLA() = delete;
+
+        auto operator=( CTRLA && ) = delete;
+
+        auto operator=( CTRLA const & ) = delete;
+
+        using Register<std::uint8_t>::operator=;
+    };
+
+    /**
+     * \brief CTRLA.
+     */
+    CTRLA ctrla;
+
+    SLPCTRL() = delete;
+
+    SLPCTRL( SLPCTRL && ) = delete;
+
+    SLPCTRL( SLPCTRL const & ) = delete;
+
+    ~SLPCTRL() = delete;
+
+    auto operator=( SLPCTRL && ) = delete;
+
+    auto operator=( SLPCTRL const & ) = delete;
+};
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_SLPCTRL_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -41,6 +41,7 @@ set(
     "picolibrary/microchip/megaavr0/peripheral/portmux.cc"
     "picolibrary/microchip/megaavr0/peripheral/rstctrl.cc"
     "picolibrary/microchip/megaavr0/peripheral/sigrow.cc"
+    "picolibrary/microchip/megaavr0/peripheral/slpctrl.cc"
     "picolibrary/microchip/megaavr0/peripheral/spi.cc"
     "picolibrary/microchip/megaavr0/peripheral/syscfg.cc"
     "picolibrary/microchip/megaavr0/peripheral/twi.cc"

--- a/source/picolibrary/microchip/megaavr0/peripheral/slpctrl.cc
+++ b/source/picolibrary/microchip/megaavr0/peripheral/slpctrl.cc
@@ -1,0 +1,29 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::SLPCTRL implementation.
+ */
+
+#include "picolibrary/microchip/megaavr0/peripheral/slpctrl.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+static_assert( sizeof( SLPCTRL ) == 0x00 + 1 );
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral


### PR DESCRIPTION
Resolves #839 (Add Microchip megaAVR 0-series SLPCTRL peripheral).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
