### PR TITLE
Add Microchip megaAVR 0-series CPUINT peripheral

### DIFF
--- a/docs/peripheral.md
+++ b/docs/peripheral.md
@@ -4,6 +4,7 @@
 1. [Peripherals](#peripherals)
     1. [BOD](#bod)
     1. [CLKCTRL](#clkctrl)
+    1. [CPUINT](#sigrow)
     1. [PORT](#port)
     1. [PORTMUX](#portmux)
     1. [RSTCTRL](#rstctrl)
@@ -51,6 +52,13 @@ The `::picolibrary::Microchip::megaAVR0::Peripheral::CLKCTRL` class defines the 
 the Microchip megaAVR 0-series CLKCTRL peripheral and information about its registers.
 The `::picolibrary::Microchip::megaAVR0::Peripheral::CLKCTRL` class is defined in the
 [`include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h)/[`source/picolibrary/microchip/megaavr0/peripheral/clkctrl.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/clkctrl.cc)
+header/source file pair.
+
+### CPUINT
+The `::picolibrary::Microchip::megaAVR0::Peripheral::CPUINT` class defines the layout of
+the Microchip megaAVR 0-series CPUINT peripheral and information about its registers.
+The `::picolibrary::Microchip::megaAVR0::Peripheral::CPUINT` class is defined in the
+[`include/picolibrary/microchip/megaavr0/peripheral/cpuint.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h)/[`source/picolibrary/microchip/megaavr0/peripheral/cpuint.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/cpuint.cc)
 header/source file pair.
 
 ### PORT
@@ -158,6 +166,7 @@ and the instance name.
 The following peripheral instances are defined (listed alphabetically):
 - `::picolibrary::Microchip::megaAVR0::Peripheral::BOD0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::CLKCTRL0`
+- `::picolibrary::Microchip::megaAVR0::Peripheral::CPUINT0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTA`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTB`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTC`

--- a/include/picolibrary/microchip/megaavr0/peripheral.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral.h
@@ -25,6 +25,7 @@
 
 #include "picolibrary/microchip/megaavr0/peripheral/bod.h"
 #include "picolibrary/microchip/megaavr0/peripheral/clkctrl.h"
+#include "picolibrary/microchip/megaavr0/peripheral/cpuint.h"
 #include "picolibrary/microchip/megaavr0/peripheral/instance.h"
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/portmux.h"
@@ -109,6 +110,11 @@ using VREF0 = Instance<VREF, 0x00A0>;
  * \brief WDT0.
  */
 using WDT0 = Instance<WDT, 0x0100>;
+
+/**
+ * \brief CPUINT0.
+ */
+using CPUINT0 = Instance<CPUINT, 0x0110>;
 
 /**
  * \brief PORTA.

--- a/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h
@@ -1,0 +1,186 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::CPUINT interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_CPUINT_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_CPUINT_H
+
+#include <cstdint>
+
+#include "picolibrary/bit_manipulation.h"
+#include "picolibrary/microchip/megaavr0/register.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+/**
+ * \brief Microchip megaAVR 0-series CPU Interrupt Controller (CPUINT) peripheral.
+ */
+class CPUINT {
+  public:
+    /**
+     * \brief Control A (CTRLA) register.
+     *
+     * This register has the following fields:
+     * - Round Robin Priority Enable (LVL0RR)
+     * - Compact Vector Table (CVT)
+     * - Interrupt Vector Select (IVSEL)
+     */
+    class CTRLA : public Register<std::uint8_t> {
+      public:
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto LVL0RR    = std::uint_fast8_t{ 1 }; ///< LVL0RR.
+            static constexpr auto RESERVED1 = std::uint_fast8_t{ 4 }; ///< RESERVED1.
+            static constexpr auto CVT       = std::uint_fast8_t{ 1 }; ///< CVT.
+            static constexpr auto IVSEL     = std::uint_fast8_t{ 1 }; ///< IVSEL.
+            static constexpr auto RESERVED7 = std::uint_fast8_t{ 1 }; ///< RESERVED7.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto LVL0RR = std::uint_fast8_t{}; ///< LVL0RR.
+            static constexpr auto RESERVED1 = std::uint_fast8_t{ LVL0RR + Size::LVL0RR }; ///< RESERVED1.
+            static constexpr auto CVT = std::uint_fast8_t{ RESERVED1 + Size::RESERVED1 }; ///< CVT.
+            static constexpr auto IVSEL = std::uint_fast8_t{ CVT + Size::CVT }; ///< IVSEL.
+            static constexpr auto RESERVED7 = std::uint_fast8_t{ IVSEL + Size::IVSEL }; ///< RESERVED7.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto LVL0RR = mask<std::uint8_t>( Size::LVL0RR, Bit::LVL0RR ); ///< LVL0RR.
+            static constexpr auto RESERVED1 = mask<std::uint8_t>( Size::RESERVED1, Bit::RESERVED1 ); ///< RESERVED1.
+            static constexpr auto CVT = mask<std::uint8_t>( Size::CVT, Bit::CVT ); ///< CVT.
+            static constexpr auto IVSEL = mask<std::uint8_t>( Size::IVSEL, Bit::IVSEL ); ///< IVSEL.
+            static constexpr auto RESERVED7 = mask<std::uint8_t>( Size::RESERVED7, Bit::RESERVED7 ); ///< RESERVED7.
+        };
+
+        CTRLA() = delete;
+
+        CTRLA( CTRLA && ) = delete;
+
+        CTRLA( CTRLA const & ) = delete;
+
+        ~CTRLA() = delete;
+
+        auto operator=( CTRLA && ) = delete;
+
+        auto operator=( CTRLA const & ) = delete;
+
+        using Register<std::uint8_t>::operator=;
+    };
+
+    /**
+     * \brief Status (STATUS) register.
+     *
+     * This register has the following fields:
+     * - Level 0 Interrupt Executing (LVL0EX)
+     * - Level 1 Interrupt Executing (LVL1EX)
+     * - Non-Maskable Interrupt Executing (NMIEX)
+     */
+    class STATUS : public Register<std::uint8_t> {
+      public:
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto LVL0EX    = std::uint_fast8_t{ 1 }; ///< LVL0EX.
+            static constexpr auto LVL1EX    = std::uint_fast8_t{ 1 }; ///< LVL1EX.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ 5 }; ///< RESERVED2.
+            static constexpr auto NMIEX     = std::uint_fast8_t{ 1 }; ///< NMIEX.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto LVL0EX = std::uint_fast8_t{}; ///< LVL0EX.
+            static constexpr auto LVL1EX = std::uint_fast8_t{ LVL0EX + Size::LVL0EX }; ///< LVL1EX.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ LVL1EX + Size::LVL1EX }; ///< RESERVED2.
+            static constexpr auto NMIEX = std::uint_fast8_t{ RESERVED2 + Size::RESERVED2 }; ///< NMIEX.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto LVL0EX = mask<std::uint8_t>( Size::LVL0EX, Bit::LVL0EX ); ///< LVL0EX.
+            static constexpr auto LVL1EX = mask<std::uint8_t>( Size::LVL1EX, Bit::LVL1EX ); ///< LVL1EX.
+            static constexpr auto RESERVED2 = mask<std::uint8_t>( Size::RESERVED2, Bit::RESERVED2 ); ///< RESERVED2.
+            static constexpr auto NMIEX = mask<std::uint8_t>( Size::NMIEX, Bit::NMIEX ); ///< NMIEX.
+        };
+
+        STATUS() = delete;
+
+        STATUS( STATUS && ) = delete;
+
+        STATUS( STATUS const & ) = delete;
+
+        ~STATUS() = delete;
+
+        auto operator=( STATUS && ) = delete;
+
+        auto operator=( STATUS const & ) = delete;
+
+        using Register<std::uint8_t>::operator=;
+    };
+
+    /**
+     * \brief CTRLA.
+     */
+    CTRLA ctrla;
+
+    /**
+     * \brief STATUS.
+     */
+    STATUS status;
+
+    /**
+     * \brief Interrupt Priority Level 0 (LVL0PRI) register.
+     */
+    Register<std::uint8_t> lvl0pri;
+
+    /**
+     * \brief Interrupt Vector with Priority Level 1 (LVL1VEC) register.
+     */
+    Register<std::uint8_t> lvl1vec;
+
+    CPUINT() = delete;
+
+    CPUINT( CPUINT && ) = delete;
+
+    CPUINT( CPUINT const & ) = delete;
+
+    ~CPUINT() = delete;
+
+    auto operator=( CPUINT && ) = delete;
+
+    auto operator=( CPUINT const & ) = delete;
+};
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_CPUINT_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -37,6 +37,7 @@ set(
     "picolibrary/microchip/megaavr0/peripheral.cc"
     "picolibrary/microchip/megaavr0/peripheral/bod.cc"
     "picolibrary/microchip/megaavr0/peripheral/clkctrl.cc"
+    "picolibrary/microchip/megaavr0/peripheral/cpuint.cc"
     "picolibrary/microchip/megaavr0/peripheral/instance.cc"
     "picolibrary/microchip/megaavr0/peripheral/port.cc"
     "picolibrary/microchip/megaavr0/peripheral/portmux.cc"

--- a/source/picolibrary/microchip/megaavr0/peripheral/cpuint.cc
+++ b/source/picolibrary/microchip/megaavr0/peripheral/cpuint.cc
@@ -1,0 +1,29 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::CPUINT implementation.
+ */
+
+#include "picolibrary/microchip/megaavr0/peripheral/cpuint.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+static_assert( sizeof( CPUINT ) == 0x03 + 1 );
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral


### PR DESCRIPTION
Resolves #842 (Add Microchip megaAVR 0-series CPUINT peripheral).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
