### PR TITLE
Add Microchip megaAVR 0-series CRCSCAN peripheral

### DIFF
--- a/docs/peripheral.md
+++ b/docs/peripheral.md
@@ -5,6 +5,7 @@
     1. [BOD](#bod)
     1. [CLKCTRL](#clkctrl)
     1. [CPUINT](#cpuint)
+    1. [CRCSCAN](#crcscan)
     1. [PORT](#port)
     1. [PORTMUX](#portmux)
     1. [RSTCTRL](#rstctrl)
@@ -59,6 +60,13 @@ The `::picolibrary::Microchip::megaAVR0::Peripheral::CPUINT` class defines the l
 the Microchip megaAVR 0-series CPUINT peripheral and information about its registers.
 The `::picolibrary::Microchip::megaAVR0::Peripheral::CPUINT` class is defined in the
 [`include/picolibrary/microchip/megaavr0/peripheral/cpuint.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h)/[`source/picolibrary/microchip/megaavr0/peripheral/cpuint.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/cpuint.cc)
+header/source file pair.
+
+### CRCSCAN
+The `::picolibrary::Microchip::megaAVR0::Peripheral::CRCSCAN` class defines the layout of
+the Microchip megaAVR 0-series CRCSCAN peripheral and information about its registers.
+The `::picolibrary::Microchip::megaAVR0::Peripheral::CRCSCAN` class is defined in the
+[`include/picolibrary/microchip/megaavr0/peripheral/crcscan.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h)/[`source/picolibrary/microchip/megaavr0/peripheral/crcscan.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/crcscan.cc)
 header/source file pair.
 
 ### PORT
@@ -167,6 +175,7 @@ The following peripheral instances are defined (listed alphabetically):
 - `::picolibrary::Microchip::megaAVR0::Peripheral::BOD0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::CLKCTRL0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::CPUINT0`
+- `::picolibrary::Microchip::megaAVR0::Peripheral::CRCSCAN0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTA`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTB`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::PORTC`

--- a/include/picolibrary/microchip/megaavr0/peripheral.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral.h
@@ -26,6 +26,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/bod.h"
 #include "picolibrary/microchip/megaavr0/peripheral/clkctrl.h"
 #include "picolibrary/microchip/megaavr0/peripheral/cpuint.h"
+#include "picolibrary/microchip/megaavr0/peripheral/crcscan.h"
 #include "picolibrary/microchip/megaavr0/peripheral/instance.h"
 #include "picolibrary/microchip/megaavr0/peripheral/port.h"
 #include "picolibrary/microchip/megaavr0/peripheral/portmux.h"
@@ -115,6 +116,11 @@ using WDT0 = Instance<WDT, 0x0100>;
  * \brief CPUINT0.
  */
 using CPUINT0 = Instance<CPUINT, 0x0110>;
+
+/**
+ * \brief CRCSCAN0.
+ */
+using CRCSCAN0 = Instance<CRCSCAN, 0x0120>;
 
 /**
  * \brief PORTA.

--- a/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
@@ -31,7 +31,8 @@
 namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
 /**
- * \brief Microchip megaAVR 0-series CPU Interrupt Controller (CRCSCAN) peripheral.
+ * \brief Microchip megaAVR 0-series Cyclic Redundancy Check Memory Scan (CRCSCAN)
+  *       peripheral.
  */
 class CRCSCAN {
   public:

--- a/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
@@ -1,0 +1,244 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::CRCSCAN interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_CRCSCAN_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_CRCSCAN_H
+
+#include <cstdint>
+
+#include "picolibrary/bit_manipulation.h"
+#include "picolibrary/microchip/megaavr0/register.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+/**
+ * \brief Microchip megaAVR 0-series CPU Interrupt Controller (CRCSCAN) peripheral.
+ */
+class CRCSCAN {
+  public:
+    /**
+     * \brief Control A (CTRLA) register.
+     *
+     * This register has the following fields:
+     * - Enable CRCSCAN (ENABLE)
+     * - Enable NMI Trigger (NMIEN)
+     * - Reset CRCSCAN (RESET)
+     */
+    class CTRLA : public Register<std::uint8_t> {
+      public:
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto ENABLE    = std::uint_fast8_t{ 1 }; ///< ENABLE.
+            static constexpr auto NMIEN     = std::uint_fast8_t{ 1 }; ///< NMIEN.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ 5 }; ///< RESERVED2.
+            static constexpr auto RESET     = std::uint_fast8_t{ 1 }; ///< RESET.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto ENABLE = std::uint_fast8_t{}; ///< ENABLE.
+            static constexpr auto NMIEN = std::uint_fast8_t{ ENABLE + Size::ENABLE }; ///< NMIEN.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ NMIEN + Size::NMIEN }; ///< RESERVED2.
+            static constexpr auto RESET = std::uint_fast8_t{ RESERVED2 + Size::RESERVED2 }; ///< RESET.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto ENABLE = mask<std::uint8_t>( Size::ENABLE, Bit::ENABLE ); ///< ENABLE.
+            static constexpr auto NMIEN = mask<std::uint8_t>( Size::NMIEN, Bit::NMIEN ); ///< NMIEN.
+            static constexpr auto RESERVED2 = mask<std::uint8_t>( Size::RESERVED2, Bit::RESERVED2 ); ///< RESERVED2.
+            static constexpr auto RESET = mask<std::uint8_t>( Size::RESET, Bit::RESET ); ///< RESET.
+        };
+
+        CTRLA() = delete;
+
+        CTRLA( CTRLA && ) = delete;
+
+        CTRLA( CTRLA const & ) = delete;
+
+        ~CTRLA() = delete;
+
+        auto operator=( CTRLA && ) = delete;
+
+        auto operator=( CTRLA const & ) = delete;
+
+        using Register<std::uint8_t>::operator=;
+    };
+
+    /**
+     * \brief Control B (CTRLB) register.
+     *
+     * This register has the following fields:
+     * - CRC Source (SRC)
+     * - CRC Flash Access Mode (MODE)
+     */
+    class CTRLB : public Register<std::uint8_t> {
+      public:
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto SRC       = std::uint_fast8_t{ 2 }; ///< SRC.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ 2 }; ///< RESERVED2.
+            static constexpr auto MODE      = std::uint_fast8_t{ 2 }; ///< MODE.
+            static constexpr auto RESERVED6 = std::uint_fast8_t{ 2 }; ///< RESERVED6.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto SRC = std::uint_fast8_t{}; ///< SRC.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ SRC + Size::SRC }; ///< RESERVED2.
+            static constexpr auto MODE = std::uint_fast8_t{ RESERVED2 + Size::RESERVED2 }; ///< MODE.
+            static constexpr auto RESERVED6 = std::uint_fast8_t{ MODE + Size::MODE }; ///< RESERVED6.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto SRC = mask<std::uint8_t>( Size::SRC, Bit::SRC ); ///< SRC.
+            static constexpr auto RESERVED2 = mask<std::uint8_t>( Size::RESERVED2, Bit::RESERVED2 ); ///< RESERVED2.
+            static constexpr auto MODE = mask<std::uint8_t>( Size::MODE, Bit::MODE ); ///< MODE.
+            static constexpr auto RESERVED6 = mask<std::uint8_t>( Size::RESERVED6, Bit::RESERVED6 ); ///< RESERVED6.
+        };
+
+        /**
+         * \brief SRC.
+         */
+        enum SRC : std::uint8_t {
+            SRC_FLASH   = 0x0 << Bit::SRC, ///< The CRC is performed on the entire Flash (boot, application code, and application data sections).
+            SRC_BOOTAPP = 0x1 << Bit::SRC, ///< The CRC is performed on the boot and application code sections of Flash.
+            SRC_BOOT = 0x2 << Bit::SRC, ///< The CRC is performed on the boot section of Flash.
+        };
+
+        /**
+         * \brief MODE.
+         */
+        enum MODE : std::uint8_t {
+            MODE_PRIORITY = 0x0 << Bit::MODE, ///< The CRC module runs a single check with priority to Flash. The CPU is halted until the CRC completes.
+        };
+
+        CTRLB() = delete;
+
+        CTRLB( CTRLB && ) = delete;
+
+        CTRLB( CTRLB const & ) = delete;
+
+        ~CTRLB() = delete;
+
+        auto operator=( CTRLB && ) = delete;
+
+        auto operator=( CTRLB const & ) = delete;
+
+        using Register<std::uint8_t>::operator=;
+    };
+
+    /**
+     * \brief Status (STATUS) register.
+     *
+     * This register has the following fields:
+     * - CRC Busy (BUSY)
+     * - CRC OK (OK)
+     */
+    class STATUS : public Register<std::uint8_t> {
+      public:
+        /**
+         * \brief Field sizes.
+         */
+        struct Size {
+            static constexpr auto BUSY      = std::uint_fast8_t{ 1 }; ///< BUSY.
+            static constexpr auto OK        = std::uint_fast8_t{ 1 }; ///< OK.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ 6 }; ///< RESERVED2.
+        };
+
+        /**
+         * \brief Field bit positions.
+         */
+        struct Bit {
+            static constexpr auto BUSY = std::uint_fast8_t{}; ///< BUSY.
+            static constexpr auto OK   = std::uint_fast8_t{ BUSY + Size::BUSY }; ///< OK.
+            static constexpr auto RESERVED2 = std::uint_fast8_t{ OK + Size::OK }; ///< RESERVED2.
+        };
+
+        /**
+         * \brief Field bit masks.
+         */
+        struct Mask {
+            static constexpr auto BUSY = mask<std::uint8_t>( Size::BUSY, Bit::BUSY ); ///< BUSY.
+            static constexpr auto OK = mask<std::uint8_t>( Size::OK, Bit::OK ); ///< OK.
+            static constexpr auto RESERVED2 = mask<std::uint8_t>( Size::RESERVED2, Bit::RESERVED2 ); ///< RESERVED2.
+        };
+
+        STATUS() = delete;
+
+        STATUS( STATUS && ) = delete;
+
+        STATUS( STATUS const & ) = delete;
+
+        ~STATUS() = delete;
+
+        auto operator=( STATUS && ) = delete;
+
+        auto operator=( STATUS const & ) = delete;
+
+        using Register<std::uint8_t>::operator=;
+    };
+
+    /**
+     * \brief CTRLA.
+     */
+    CTRLA ctrla;
+
+    /**
+     * \brief CTRLB.
+     */
+    CTRLB ctrlb;
+
+    /**
+     * \brief STATUS.
+     */
+    STATUS status;
+
+    CRCSCAN() = delete;
+
+    CRCSCAN( CRCSCAN && ) = delete;
+
+    CRCSCAN( CRCSCAN const & ) = delete;
+
+    ~CRCSCAN() = delete;
+
+    auto operator=( CRCSCAN && ) = delete;
+
+    auto operator=( CRCSCAN const & ) = delete;
+};
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_CRCSCAN_H

--- a/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
@@ -32,7 +32,7 @@ namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
 /**
  * \brief Microchip megaAVR 0-series Cyclic Redundancy Check Memory Scan (CRCSCAN)
-  *       peripheral.
+ *        peripheral.
  */
 class CRCSCAN {
   public:

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -38,6 +38,7 @@ set(
     "picolibrary/microchip/megaavr0/peripheral/bod.cc"
     "picolibrary/microchip/megaavr0/peripheral/clkctrl.cc"
     "picolibrary/microchip/megaavr0/peripheral/cpuint.cc"
+    "picolibrary/microchip/megaavr0/peripheral/crcscan.cc"
     "picolibrary/microchip/megaavr0/peripheral/instance.cc"
     "picolibrary/microchip/megaavr0/peripheral/port.cc"
     "picolibrary/microchip/megaavr0/peripheral/portmux.cc"

--- a/source/picolibrary/microchip/megaavr0/peripheral/crcscan.cc
+++ b/source/picolibrary/microchip/megaavr0/peripheral/crcscan.cc
@@ -1,0 +1,29 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::CRCSCAN implementation.
+ */
+
+#include "picolibrary/microchip/megaavr0/peripheral/crcscan.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+static_assert( sizeof( CRCSCAN ) == 0x02 + 1 );
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral


### PR DESCRIPTION
Resolves #843 (Add Microchip megaAVR 0-series CRCSCAN peripheral).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
