### PR TITLE
Fix Microchip megaAVR 0-series peripheral register constness

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/bod.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/bod.h
@@ -374,7 +374,7 @@ class BOD {
     /**
      * \brief CTRLB.
      */
-    CTRLB ctrlb;
+    CTRLB const ctrlb;
 
     /**
      * \brief Reserved registers (offset 0x02-0x07).
@@ -399,7 +399,7 @@ class BOD {
     /**
      * \brief STATUS.
      */
-    STATUS status;
+    STATUS const status;
 
     BOD() = delete;
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h
@@ -156,7 +156,7 @@ class CPUINT {
     /**
      * \brief STATUS.
      */
-    STATUS status;
+    STATUS const status;
 
     /**
      * \brief Interrupt Priority Level 0 (LVL0PRI) register.

--- a/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/crcscan.h
@@ -225,7 +225,7 @@ class CRCSCAN {
     /**
      * \brief STATUS.
      */
-    STATUS status;
+    STATUS const status;
 
     CRCSCAN() = delete;
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/rtc.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/rtc.h
@@ -704,7 +704,7 @@ class RTC {
     /**
      * \brief STATUS.
      */
-    STATUS status;
+    STATUS const status;
 
     /**
      * \brief INTCTRL.
@@ -764,7 +764,7 @@ class RTC {
     /**
      * \brief PITSTATUS.
      */
-    PITSTATUS pitstatus;
+    PITSTATUS const pitstatus;
 
     /**
      * \brief PITINTCTRL.


### PR DESCRIPTION
Resolves #862 (Fix Microchip megaAVR 0-series peripheral register constness).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
