### PR TITLE
Fix Microchip megaAVR 0-series RTC peripheral documentation

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/rtc.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/rtc.h
@@ -31,7 +31,7 @@
 namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
 /**
- * \brief Microchip megaAVR 0-series Serial Peripheral Interface (RTC) peripheral.
+ * \brief Microchip megaAVR 0-series Real-Time Counter (RTC) peripheral.
  */
 class RTC {
   public:


### PR DESCRIPTION
Resolves #865 (Fix Microchip megaAVR 0-series RTC peripheral documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
