### PR TITLE
Add Microchip megaAVR 0-series protected register CPU peripheral CCP register key configuration

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/bod.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/bod.h
@@ -43,7 +43,7 @@ class BOD {
      * - Active (ACTIVE)
      * - Sample Frequency (SAMPFREQ)
      */
-    class CTRLA : public Protected_Register<std::uint8_t> {
+    class CTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -106,7 +106,7 @@ class BOD {
 
         auto operator=( CTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**

--- a/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/clkctrl.h
@@ -42,7 +42,7 @@ class CLKCTRL {
      * - Clock Select (CLKSEL)
      * - System Clock Out (CLKOUT)
      */
-    class MCLKCTRLA : public Protected_Register<std::uint8_t> {
+    class MCLKCTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -93,7 +93,7 @@ class CLKCTRL {
 
         auto operator=( MCLKCTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -103,7 +103,7 @@ class CLKCTRL {
      * - Prescaler Enable (PEN)
      * - Prescaler Division (PDIV)
      */
-    class MCLKCTRLB : public Protected_Register<std::uint8_t> {
+    class MCLKCTRLB : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -161,7 +161,7 @@ class CLKCTRL {
 
         auto operator=( MCLKCTRLB const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -170,7 +170,7 @@ class CLKCTRL {
      * This register has the following fields:
      * - Lock Enable (LOCKEN)
      */
-    class MCLKLOCK : public Protected_Register<std::uint8_t> {
+    class MCLKLOCK : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -208,7 +208,7 @@ class CLKCTRL {
 
         auto operator=( MCLKLOCK const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -280,7 +280,7 @@ class CLKCTRL {
      * This register has the following fields:
      * - Run Standby (RUNSTDBY)
      */
-    class OSC20MCTRLA : public Protected_Register<std::uint8_t> {
+    class OSC20MCTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -321,7 +321,7 @@ class CLKCTRL {
 
         auto operator=( OSC20MCTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -330,7 +330,7 @@ class CLKCTRL {
      * This register has the following fields:
      * - Calibration (CAL20M)
      */
-    class OSC20MCALIBA : public Protected_Register<std::uint8_t> {
+    class OSC20MCALIBA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -368,7 +368,7 @@ class CLKCTRL {
 
         auto operator=( OSC20MCALIBA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -378,7 +378,7 @@ class CLKCTRL {
      * - Oscillator Temperature Coefficient Calibration (TEMPCAL20M)
      * - Oscillator Calibration Locked by Fuse (LOCK)
      */
-    class OSC20MCALIBB : public Protected_Register<std::uint8_t> {
+    class OSC20MCALIBB : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -419,7 +419,7 @@ class CLKCTRL {
 
         auto operator=( OSC20MCALIBB const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -428,7 +428,7 @@ class CLKCTRL {
      * This register has the following fields:
      * - Run Standby (RUNSTBY)
      */
-    class OSC32KCTRLA : public Protected_Register<std::uint8_t> {
+    class OSC32KCTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -469,7 +469,7 @@ class CLKCTRL {
 
         auto operator=( OSC32KCTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -481,7 +481,7 @@ class CLKCTRL {
      * - Source Select (SEL)
      * - Crystal Start-Up Time (CSUT)
      */
-    class XOSC32KCTRLA : public Protected_Register<std::uint8_t> {
+    class XOSC32KCTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -541,7 +541,7 @@ class CLKCTRL {
 
         auto operator=( XOSC32KCTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**

--- a/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/cpuint.h
@@ -43,7 +43,7 @@ class CPUINT {
      * - Compact Vector Table (CVT)
      * - Interrupt Vector Select (IVSEL)
      */
-    class CTRLA : public Protected_Register<std::uint8_t> {
+    class CTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -90,7 +90,7 @@ class CPUINT {
 
         auto operator=( CTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**

--- a/include/picolibrary/microchip/megaavr0/peripheral/rstctrl.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/rstctrl.h
@@ -108,7 +108,7 @@ class RSTCTRL {
      * This register has the following fields:
      * - Software Reset Enable (SWRE)
      */
-    class SWRR : public Protected_Register<std::uint8_t> {
+    class SWRR : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -146,7 +146,7 @@ class RSTCTRL {
 
         auto operator=( SWRR const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**

--- a/include/picolibrary/microchip/megaavr0/peripheral/wdt.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/wdt.h
@@ -42,7 +42,7 @@ class WDT {
      * - Period (PERIOD)
      * - Window (WINDOW)
      */
-    class CTRLA : public Protected_Register<std::uint8_t> {
+    class CTRLA : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -116,7 +116,7 @@ class WDT {
 
         auto operator=( CTRLA const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**
@@ -126,7 +126,7 @@ class WDT {
      * - Synchronization Busy (SYNCBUSY)
      * - Lock (LOCK)
      */
-    class STATUS : public Protected_Register<std::uint8_t> {
+    class STATUS : public Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG> {
       public:
         /**
          * \brief Field sizes.
@@ -167,7 +167,7 @@ class WDT {
 
         auto operator=( STATUS const & ) = delete;
 
-        using Protected_Register<std::uint8_t>::operator=;
+        using Protected_Register<std::uint8_t, CPU_CCP_Key::IOREG>::operator=;
     };
 
     /**

--- a/include/picolibrary/microchip/megaavr0/register.h
+++ b/include/picolibrary/microchip/megaavr0/register.h
@@ -26,6 +26,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "picolibrary/utility.h"
+
 namespace picolibrary::Microchip::megaAVR0 {
 
 /**
@@ -163,11 +165,20 @@ class Reserved_Register {
 };
 
 /**
+ * \brief Microchip megaAVR 0-series CPU peripheral CCP register key.
+ */
+enum class CPU_CCP_Key : std::uint8_t {
+    SPM   = 0x9D, ///< Allow self programming.
+    IOREG = 0xD8, ///< Unlock protected I/O registers.
+};
+
+/**
  * \brief A Microchip megaAVR 0-series protected register.
  *
  * \tparam T The protected register's underlying integral type (must be std::uint8_t).
+ * \tparam CPU_CCP_KEY The protected register's CPU peripheral CCP register key.
  */
-template<typename T>
+template<typename T, CPU_CCP_Key CPU_CCP_KEY>
 class Protected_Register {
   public:
     static_assert( std::is_same_v<T, std::uint8_t> );
@@ -272,11 +283,6 @@ class Protected_Register {
     static constexpr auto CPU_CCP_ADDRESS = std::uintptr_t{ CPU_ADDRESS + CPU_CCP_OFFSET };
 
     /**
-     * \brief CPU peripheral CCP register unlock protected I/O registers signature.
-     */
-    static constexpr auto CPU_CCP_UNLOCK_PROTECTED_IO_REGISTERS = std::uint8_t{ 0xD8 };
-
-    /**
      * \brief The protected register.
      */
     Type volatile m_protected_register;
@@ -293,7 +299,7 @@ class Protected_Register {
             "sts %[protected_register_address], %[protected_register_data]"
             :
             : [ cpu_ccp_address ] "I"( CPU_CCP_ADDRESS ),
-              [ cpu_ccp_unlock_protected_io_registers ] "d"( CPU_CCP_UNLOCK_PROTECTED_IO_REGISTERS ),
+              [ cpu_ccp_unlock_protected_io_registers ] "d"( to_underlying( CPU_CCP_KEY ) ),
               [ protected_register_address ] "n"( &m_protected_register ),
               [ protected_register_data ] "r"( data ) );
     }

--- a/include/picolibrary/microchip/megaavr0/register.h
+++ b/include/picolibrary/microchip/megaavr0/register.h
@@ -168,7 +168,7 @@ class Reserved_Register {
  * \brief Microchip megaAVR 0-series CPU peripheral CCP register key.
  */
 enum class CPU_CCP_Key : std::uint8_t {
-    SPM   = 0x9D, ///< Allow self programming.
+    SPM   = 0x9D, ///< Allow self-programming.
     IOREG = 0xD8, ///< Unlock protected I/O registers.
 };
 


### PR DESCRIPTION
Resolves #868 (Add Microchip megaAVR 0-series protected register CPU peripheral CCP register key configuration).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
