### PR TITLE
Add Microchip megaAVR 0-series 16-bit register low/high byte registers

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral/adc.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/adc.h
@@ -885,7 +885,7 @@ class ADC {
             Register<std::uint8_t> winltl;
 
             /**
-             * \brief Window Comparator Low Threshold High Byte (WINLTL) register.
+             * \brief Window Comparator Low Threshold High Byte (WINLTH) register.
              */
             Register<std::uint8_t> winlth;
         };
@@ -904,7 +904,7 @@ class ADC {
             Register<std::uint8_t> winhtl;
 
             /**
-             * \brief Window Comparator High Threshold High Byte (WINHTL) register.
+             * \brief Window Comparator High Threshold High Byte (WINHTH) register.
              */
             Register<std::uint8_t> winhth;
         };

--- a/include/picolibrary/microchip/megaavr0/peripheral/adc.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/adc.h
@@ -853,20 +853,62 @@ class ADC {
      */
     Reserved_Register<std::uint8_t> const reserved_0x0E_0x0F[ ( 0x0F - 0x0E ) + 1 ];
 
-    /**
-     * \brief Result (RES) register.
-     */
-    Register<std::uint16_t> const res;
+    union {
+        /**
+         * \brief Result (RES) register.
+         */
+        Register<std::uint16_t> const res;
 
-    /**
-     * \brief Window Comparator Low Threshold (WINLT) register.
-     */
-    Register<std::uint16_t> winlt;
+        struct {
+            /**
+             * \brief Result Low Byte (RESL) register.
+             */
+            Register<std::uint8_t> const resl;
 
-    /**
-     * \brief Window Comparator High Threshold (WINHT) register.
-     */
-    Register<std::uint16_t> winht;
+            /**
+             * \brief Result High Byte (RESH) register.
+             */
+            Register<std::uint8_t> const resh;
+        };
+    };
+
+    union {
+        /**
+         * \brief Window Comparator Low Threshold (WINLT) register.
+         */
+        Register<std::uint16_t> winlt;
+
+        struct {
+            /**
+             * \brief Window Comparator Low Threshold Low Byte (WINLTL) register.
+             */
+            Register<std::uint8_t> winltl;
+
+            /**
+             * \brief Window Comparator Low Threshold High Byte (WINLTL) register.
+             */
+            Register<std::uint8_t> winlth;
+        };
+    };
+
+    union {
+        /**
+         * \brief Window Comparator High Threshold (WINHT) register.
+         */
+        Register<std::uint16_t> winht;
+
+        struct {
+            /**
+             * \brief Window Comparator High Threshold Low Byte (WINHTL) register.
+             */
+            Register<std::uint8_t> winhtl;
+
+            /**
+             * \brief Window Comparator High Threshold High Byte (WINHTL) register.
+             */
+            Register<std::uint8_t> winhth;
+        };
+    };
 
     /**
      * \brief CALIB.

--- a/include/picolibrary/microchip/megaavr0/peripheral/nvmctrl.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/nvmctrl.h
@@ -326,15 +326,43 @@ class NVMCTRL {
      */
     Reserved_Register<std::uint8_t> const reserved_0x05_0x05[ ( 0x05 - 0x05 ) + 1 ];
 
-    /**
-     * \brief Data (DATA) register.
-     */
-    Register<std::uint16_t> data;
+    union {
+        /**
+         * \brief Data (DATA) register.
+         */
+        Register<std::uint16_t> data;
 
-    /**
-     * \brief Address (ADDR) register.
-     */
-    Register<std::uint16_t> addr;
+        struct {
+            /**
+             * \brief Data Low Byte (DATAL) register.
+             */
+            Register<std::uint8_t> datal;
+
+            /**
+             * \brief Data High Byte (DATAH) register.
+             */
+            Register<std::uint8_t> datah;
+        };
+    };
+
+    union {
+        /**
+         * \brief Address (ADDR) register.
+         */
+        Register<std::uint16_t> addr;
+
+        struct {
+            /**
+             * \brief Address Low Byte (ADDRL) register.
+             */
+            Register<std::uint8_t> addrl;
+
+            /**
+             * \brief Address High Byte (ADDRH) register.
+             */
+            Register<std::uint8_t> addrh;
+        };
+    };
 
     NVMCTRL() = delete;
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/rtc.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/rtc.h
@@ -736,20 +736,62 @@ class RTC {
      */
     CLKSEL clksel;
 
-    /**
-     * \brief Count (CNT) register.
-     */
-    Register<std::uint16_t> cnt;
+    union {
+        /**
+         * \brief Count (CNT) register.
+         */
+        Register<std::uint16_t> cnt;
 
-    /**
-     * \brief Period (PER) register.
-     */
-    Register<std::uint16_t> per;
+        struct {
+            /**
+             * \brief Count Low Byte (CNTL) register.
+             */
+            Register<std::uint8_t> cntl;
 
-    /**
-     * \brief Compare (CMP) register.
-     */
-    Register<std::uint16_t> cmp;
+            /**
+             * \brief Count High Byte (CNTH) register.
+             */
+            Register<std::uint8_t> cnth;
+        };
+    };
+
+    union {
+        /**
+         * \brief Period (PER) register.
+         */
+        Register<std::uint16_t> per;
+
+        struct {
+            /**
+             * \brief Period Low Byte (PERL) register.
+             */
+            Register<std::uint8_t> perl;
+
+            /**
+             * \brief Period High Byte (PERH) register.
+             */
+            Register<std::uint8_t> perh;
+        };
+    };
+
+    union {
+        /**
+         * \brief Compare (CMP) register.
+         */
+        Register<std::uint16_t> cmp;
+
+        struct {
+            /**
+             * \brief Compare Low Byte (CMPL) register.
+             */
+            Register<std::uint8_t> cmpl;
+
+            /**
+             * \brief Compare High Byte (CMPH) register.
+             */
+            Register<std::uint8_t> cmph;
+        };
+    };
 
     /**
      * \brief Reserved registers (offset 0x0E-0x0F).

--- a/include/picolibrary/microchip/megaavr0/peripheral/tca.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/tca.h
@@ -859,60 +859,186 @@ class TCA {
          */
         Reserved_Register<std::uint8_t> const reserved_0x10_0x1F[ ( 0x1F - 0x10 ) + 1 ];
 
-        /**
-         * \brief Counter (CNT) register.
-         */
-        Register<std::uint16_t> cnt;
+        union {
+            /**
+             * \brief Counter (CNT) register.
+             */
+            Register<std::uint16_t> cnt;
+
+            struct {
+                /**
+                 * \brief Counter Low Byte (CNTL) register.
+                 */
+                Register<std::uint8_t> cntl;
+
+                /**
+                 * \brief Counter High Byte (CNTH) register.
+                 */
+                Register<std::uint8_t> cnth;
+            };
+        };
 
         /**
          * \brief Reserved registers (offset 0x22-0x25).
          */
         Reserved_Register<std::uint8_t> const reserved_0x22_0x25[ ( 0x25 - 0x22 ) + 1 ];
 
-        /**
-         * \brief Period (PER) register.
-         */
-        Register<std::uint16_t> per;
+        union {
+            /**
+             * \brief Period (PER) register.
+             */
+            Register<std::uint16_t> per;
 
-        /**
-         * \brief Compare 0 (CMP0) register.
-         */
-        Register<std::uint16_t> cmp0;
+            struct {
+                /**
+                 * \brief Period Low Byte (PERL) register.
+                 */
+                Register<std::uint8_t> perl;
 
-        /**
-         * \brief Compare 1 (CMP1) register.
-         */
-        Register<std::uint16_t> cmp1;
+                /**
+                 * \brief Period High Byte (PERH) register.
+                 */
+                Register<std::uint8_t> perh;
+            };
+        };
 
-        /**
-         * \brief Compare 2 (CMP2) register.
-         */
-        Register<std::uint16_t> cmp2;
+        union {
+            /**
+             * \brief Compare 0 (CMP0) register.
+             */
+            Register<std::uint16_t> cmp0;
+
+            struct {
+                /**
+                 * \brief Compare 0 Low Byte (CMP0L) register.
+                 */
+                Register<std::uint8_t> cmp0l;
+
+                /**
+                 * \brief Compare 0 High Byte (CMP0H) register.
+                 */
+                Register<std::uint8_t> cmp0h;
+            };
+        };
+
+        union {
+            /**
+             * \brief Compare 1 (CMP1) register.
+             */
+            Register<std::uint16_t> cmp1;
+
+            struct {
+                /**
+                 * \brief Compare 1 Low Byte (CMP1L) register.
+                 */
+                Register<std::uint8_t> cmp1l;
+
+                /**
+                 * \brief Compare 1 High Byte (CMP1H) register.
+                 */
+                Register<std::uint8_t> cmp1h;
+            };
+        };
+
+        union {
+            /**
+             * \brief Compare 2 (CMP2) register.
+             */
+            Register<std::uint16_t> cmp2;
+
+            struct {
+                /**
+                 * \brief Compare 2 Low Byte (CMP2L) register.
+                 */
+                Register<std::uint8_t> cmp2l;
+
+                /**
+                 * \brief Compare 2 High Byte (CMP2H) register.
+                 */
+                Register<std::uint8_t> cmp2h;
+            };
+        };
 
         /**
          * \brief Reserved registers (offset 0x2E-0x35).
          */
         Reserved_Register<std::uint8_t> const reserved_0x2E_0x35[ ( 0x35 - 0x2E ) + 1 ];
 
-        /**
-         * \brief Period Buffer (PERBUF) register.
-         */
-        Register<std::uint16_t> perbuf;
+        union {
+            /**
+             * \brief Period Buffer (PERBUF) register.
+             */
+            Register<std::uint16_t> perbuf;
 
-        /**
-         * \brief Compare 0 Buffer (CMP0BUF) register.
-         */
-        Register<std::uint16_t> cmp0buf;
+            struct {
+                /**
+                 * \brief Period Buffer Low Byte (PERBUFL) register.
+                 */
+                Register<std::uint8_t> perbufl;
 
-        /**
-         * \brief Compare 1 Buffer (CMP1BUF) register.
-         */
-        Register<std::uint16_t> cmp1buf;
+                /**
+                 * \brief Period Buffer High Byte (PERBUFH) register.
+                 */
+                Register<std::uint8_t> perbufh;
+            };
+        };
 
-        /**
-         * \brief Compare 2 Buffer (CMP2BUF) register.
-         */
-        Register<std::uint16_t> cmp2buf;
+        union {
+            /**
+             * \brief Compare 0 Buffer (CMP0BUF) register.
+             */
+            Register<std::uint16_t> cmp0buf;
+
+            struct {
+                /**
+                 * \brief Compare 0 Buffer Low Byte (CMP0BUFL) register.
+                 */
+                Register<std::uint8_t> cmp0bufl;
+
+                /**
+                 * \brief Compare 0 Buffer High Byte (CMP0BUFH) register.
+                 */
+                Register<std::uint8_t> cmp0bufh;
+            };
+        };
+
+        union {
+            /**
+             * \brief Compare 1 Buffer (CMP1BUF) register.
+             */
+            Register<std::uint16_t> cmp1buf;
+
+            struct {
+                /**
+                 * \brief Compare 1 Buffer Low Byte (CMP1BUFL) register.
+                 */
+                Register<std::uint8_t> cmp1bufl;
+
+                /**
+                 * \brief Compare 1 Buffer High Byte (CMP1BUFH) register.
+                 */
+                Register<std::uint8_t> cmp1bufh;
+            };
+        };
+
+        union {
+            /**
+             * \brief Compare 2 Buffer (CMP2BUF) register.
+             */
+            Register<std::uint16_t> cmp2buf;
+
+            struct {
+                /**
+                 * \brief Compare 2 Buffer Low Byte (CMP2BUFL) register.
+                 */
+                Register<std::uint8_t> cmp2bufl;
+
+                /**
+                 * \brief Compare 2 Buffer High Byte (CMP2BUFH) register.
+                 */
+                Register<std::uint8_t> cmp2bufh;
+            };
+        };
 
         Normal() = delete;
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/tcb.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/tcb.h
@@ -479,15 +479,43 @@ class TCB {
      */
     Register<std::uint8_t> temp;
 
-    /**
-     * \brief Count (CNT) register.
-     */
-    Register<std::uint16_t> cnt;
+    union {
+        /**
+         * \brief Count (CNT) register.
+         */
+        Register<std::uint16_t> cnt;
 
-    /**
-     * \brief Capture/Compare (CCMP) register.
-     */
-    Register<std::uint16_t> ccmp;
+        struct {
+            /**
+             * \brief Count Low Byte (CNTL) register.
+             */
+            Register<std::uint8_t> cntl;
+
+            /**
+             * \brief Count High Byte (CNTH) register.
+             */
+            Register<std::uint8_t> cnth;
+        };
+    };
+
+    union {
+        /**
+         * \brief Capture/Compare (CCMP) register.
+         */
+        Register<std::uint16_t> ccmp;
+
+        struct {
+            /**
+             * \brief Capture/Compare Low Byte (CCMPL) register.
+             */
+            Register<std::uint8_t> ccmpl;
+
+            /**
+             * \brief Capture/Compare High Byte (CCMPH) register.
+             */
+            Register<std::uint8_t> ccmph;
+        };
+    };
 
     TCB() = delete;
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/usart.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/usart.h
@@ -719,10 +719,24 @@ class USART {
      */
     CTRLC ctrlc;
 
-    /**
-     * \brief Baud (BAUD) register.
-     */
-    Register<std::uint16_t> baud;
+    union {
+        /**
+         * \brief Baud (BAUD) register.
+         */
+        Register<std::uint16_t> baud;
+
+        struct {
+            /**
+             * \brief Baud Low Byte (BAUDL) register.
+             */
+            Register<std::uint8_t> baudl;
+
+            /**
+             * \brief Baud High Byte (BAUDH) register.
+             */
+            Register<std::uint8_t> baudh;
+        };
+    };
 
     /**
      * \brief CTRLD.


### PR DESCRIPTION
Resolves #876 (Add Microchip megaAVR 0-series 16-bit register low/high byte registers).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
