### PR TITLE
Add Microchip megaAVR 0-series USERROW peripheral

### DIFF
--- a/docs/peripheral.md
+++ b/docs/peripheral.md
@@ -22,6 +22,7 @@
     1. [TCB](#tcb)
     1. [TWI](#twi)
     1. [USART](#usart)
+    1. [USERROW](#userrow)
     1. [VPORT](#vport)
     1. [VREF](#vref)
     1. [WDT](#wdt)
@@ -202,6 +203,13 @@ The `::picolibrary::Microchip::megaAVR0::Peripheral::USART` class is defined in 
 [`include/picolibrary/microchip/megaavr0/peripheral/usart.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/usart.h)/[`source/picolibrary/microchip/megaavr0/peripheral/usart.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/usart.cc)
 header/source file pair.
 
+### USERROW
+The `::picolibrary::Microchip::megaAVR0::Peripheral::USERROW` class defines the layout of
+the Microchip megaAVR 0-series USERROW peripheral.
+The `::picolibrary::Microchip::megaAVR0::Peripheral::USERROW` class is defined in the
+[`include/picolibrary/microchip/megaavr0/peripheral/userrow.h`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/include/picolibrary/microchip/megaavr0/peripheral/userrow.h)/[`source/picolibrary/microchip/megaavr0/peripheral/userrow.cc`](https://github.com/apcountryman/picolibrary-microchip-megaavr0/blob/main/source/picolibrary/microchip/megaavr0/peripheral/userrow.cc)
+header/source file pair.
+
 ### VPORT
 The `::picolibrary::Microchip::megaAVR0::Peripheral::VPORT` class defines the layout of
 the Microchip megaAVR 0-series VPORT peripheral.
@@ -273,6 +281,7 @@ The following peripheral instances are defined (listed alphabetically):
 - `::picolibrary::Microchip::megaAVR0::Peripheral::USART1`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::USART2`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::USART3`
+- `::picolibrary::Microchip::megaAVR0::Peripheral::USERRROW0`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::VPORTA`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::VPORTB`
 - `::picolibrary::Microchip::megaAVR0::Peripheral::VPORTC`

--- a/include/picolibrary/microchip/megaavr0/peripheral.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral.h
@@ -44,6 +44,7 @@
 #include "picolibrary/microchip/megaavr0/peripheral/tcb.h"
 #include "picolibrary/microchip/megaavr0/peripheral/twi.h"
 #include "picolibrary/microchip/megaavr0/peripheral/usart.h"
+#include "picolibrary/microchip/megaavr0/peripheral/userrow.h"
 #include "picolibrary/microchip/megaavr0/peripheral/vport.h"
 #include "picolibrary/microchip/megaavr0/peripheral/vref.h"
 #include "picolibrary/microchip/megaavr0/peripheral/wdt.h"
@@ -262,6 +263,11 @@ using SIGROW0 = Instance<SIGROW, 0x1100>;
  * \brief FUSE0.
  */
 using FUSE0 = Instance<FUSE, 0x1280>;
+
+/**
+ * \brief USERROW0.
+ */
+using USERROW0 = Instance<USERROW, 0x1300>;
 
 } // namespace picolibrary::Microchip::megaAVR0::Peripheral
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/userrow.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/userrow.h
@@ -35,20 +35,20 @@ namespace picolibrary::Microchip::megaAVR0::Peripheral {
 class USERROW {
   public:
 #if defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) \
-    || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+    || defined( __AVR_ATmega1608__ ) || defined( __AVR_ATmega1609__ )
     /**
      * \brief Data.
      */
     Register<std::uint8_t> data[ 32 ];
-#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608__ ) || defined( __AVR_ATmega1609__ )
 
 #if defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) \
-    || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+    || defined( __AVR_ATmega4808__ ) || defined( __AVR_ATmega4809__ )
     /**
      * \brief Data.
      */
     Register<std::uint8_t> data[ 64 ];
-#endif // defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+#endif // defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808__ ) || defined( __AVR_ATmega4809__ )
 
     USERROW() = delete;
 

--- a/include/picolibrary/microchip/megaavr0/peripheral/userrow.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral/userrow.h
@@ -1,0 +1,68 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::USERROW interface.
+ */
+
+#ifndef PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_USERROW_H
+#define PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_USERROW_H
+
+#include <cstdint>
+
+#include "picolibrary/microchip/megaavr0/register.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+/**
+ * \brief Microchip megaAVR 0-series User Row (USERROW) peripheral.
+ */
+class USERROW {
+  public:
+#if defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) \
+    || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+    /**
+     * \brief Data.
+     */
+    Register<std::uint8_t> data[ 32 ];
+#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+
+#if defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) \
+    || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+    /**
+     * \brief Data.
+     */
+    Register<std::uint8_t> data[ 64 ];
+#endif // defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+
+    USERROW() = delete;
+
+    USERROW( USERROW && ) = delete;
+
+    USERROW( USERROW const & ) = delete;
+
+    ~USERROW() = delete;
+
+    auto operator=( USERROW && ) = delete;
+
+    auto operator=( USERROW const & ) = delete;
+};
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral
+
+#endif // PICOLIBRARY_MICROCHIP_MEGAAVR0_PERIPHERAL_USERROW_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -56,6 +56,7 @@ set(
     "picolibrary/microchip/megaavr0/peripheral/tcb.cc"
     "picolibrary/microchip/megaavr0/peripheral/twi.cc"
     "picolibrary/microchip/megaavr0/peripheral/usart.cc"
+    "picolibrary/microchip/megaavr0/peripheral/userrow.cc"
     "picolibrary/microchip/megaavr0/peripheral/vport.cc"
     "picolibrary/microchip/megaavr0/peripheral/vref.cc"
     "picolibrary/microchip/megaavr0/peripheral/wdt.cc"

--- a/source/picolibrary/microchip/megaavr0/peripheral/userrow.cc
+++ b/source/picolibrary/microchip/megaavr0/peripheral/userrow.cc
@@ -25,13 +25,13 @@
 namespace picolibrary::Microchip::megaAVR0::Peripheral {
 
 #if defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) \
-    || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+    || defined( __AVR_ATmega1608__ ) || defined( __AVR_ATmega1609__ )
 static_assert( sizeof( USERROW ) == 32 );
-#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608__ ) || defined( __AVR_ATmega1609__ )
 
 #if defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) \
-    || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+    || defined( __AVR_ATmega4808__ ) || defined( __AVR_ATmega4809__ )
 static_assert( sizeof( USERROW ) == 64 );
-#endif // defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+#endif // defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808__ ) || defined( __AVR_ATmega4809__ )
 
 } // namespace picolibrary::Microchip::megaAVR0::Peripheral

--- a/source/picolibrary/microchip/megaavr0/peripheral/userrow.cc
+++ b/source/picolibrary/microchip/megaavr0/peripheral/userrow.cc
@@ -1,0 +1,37 @@
+/**
+ * picolibrary-microchip-megaavr0
+ *
+ * Copyright 2021-2023, Andrew Countryman <apcountryman@gmail.com> and the
+ * picolibrary-microchip-megaavr0 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::megaAVR0::Peripheral::USERROW implementation.
+ */
+
+#include "picolibrary/microchip/megaavr0/peripheral/userrow.h"
+
+namespace picolibrary::Microchip::megaAVR0::Peripheral {
+
+#if defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) \
+    || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+static_assert( sizeof( USERROW ) == 32 );
+#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608 ) || defined( __AVR_ATmega1609 )
+
+#if defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) \
+    || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+static_assert( sizeof( USERROW ) == 64 );
+#endif // defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808 ) || defined( __AVR_ATmega4809 )
+
+} // namespace picolibrary::Microchip::megaAVR0::Peripheral


### PR DESCRIPTION
Resolves #853 (Add Microchip megaAVR 0-series USERROW peripheral).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
