### PR TITLE
Fix Microchip megaAVR 0-series TCB3 peripheral instance availability

### DIFF
--- a/include/picolibrary/microchip/megaavr0/peripheral.h
+++ b/include/picolibrary/microchip/megaavr0/peripheral.h
@@ -251,10 +251,13 @@ using TCB1 = Instance<TCB, 0x0A90>;
  */
 using TCB2 = Instance<TCB, 0x0AA0>;
 
+#if defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) \
+    || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
 /**
  * \brief TCB3.
  */
 using TCB3 = Instance<TCB, 0x0AB0>;
+#endif // defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4809__ )
 
 /**
  * \brief SYSCFG0.


### PR DESCRIPTION
Resolves #880 (Fix Microchip megaAVR 0-series TCB3 peripheral instance availability).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
