### PR TITLE
Improve Microchip megaAVR 0-series I2C basic controller constructor parameter documentation wording

### DIFF
--- a/include/picolibrary/microchip/megaavr0/i2c.h
+++ b/include/picolibrary/microchip/megaavr0/i2c.h
@@ -82,7 +82,7 @@ class Basic_Controller {
      * \attention The TWI peripheral's routing configuration must be set prior to using
      *            this constructor.
      *
-     * \param[in] twi The TWI to be used by the controller.
+     * \param[in] twi The TWI peripheral to be used by the controller.
      * \param[in] twi_sda_hold_time The desired TWI SDA hold time.
      * \param[in] twi_bus_speed The desired TWI bus speed configuration.
      * \param[in] twi_clock_generator_scaling_factor The desired TWI clock generator
@@ -104,7 +104,7 @@ class Basic_Controller {
     /**
      * \brief Constructor.
      *
-     * \param[in] twi The TWI to be used by the controller.
+     * \param[in] twi The TWI peripheral to be used by the controller.
      * \param[in] twi_sda_hold_time The desired TWI SDA hold time.
      * \param[in] twi_bus_speed The desired TWI bus speed configuration.
      * \param[in] twi_clock_generator_scaling_factor The desired TWI clock generator


### PR DESCRIPTION
Resolves #887 (Improve Microchip megaAVR 0-series I2C basic controller constructor parameter documentation wording).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
