### PR TITLE
Add Adafruit PID781 facilities interactive testing skeleton

### DIFF
--- a/test/interactive/picolibrary/adafruit/pid781/CMakeLists.txt
+++ b/test/interactive/picolibrary/adafruit/pid781/CMakeLists.txt
@@ -13,7 +13,4 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Adafruit interactive tests CMake rules.
-
-# build the picolibrary::Adafruit::PID781 interactive tests
-add_subdirectory( pid781 )
+# Description: picolibrary::Adafruit::PID781 interactive tests CMake rules.


### PR DESCRIPTION
Resolves #898 (Add Adafruit PID781 facilities interactive testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
