### PR TITLE
Add Microchip megaAVR 0-series watchdog timer period getters

### DIFF
--- a/docs/watchdog_timer.md
+++ b/docs/watchdog_timer.md
@@ -12,6 +12,12 @@ The following Microchip megaAVR 0-series watchdog timer configuration operations
 supported:
 - To enable the watchdog timer, use the
   `::picolibrary::Microchip::megaAVR0::Watchdog_Timer::enable()` functions.
+- To get the watchdog timer time-out period, use the
+  `::picolibrary::Microchip::megaAVR0::Watchdog_Timer::period()` function.
+- To get the watchdog timer window closed period, use the
+  `::picolibrary::Microchip::megaAVR0::Watchdog_Timer::closed_period()` function.
+- To get the watchdog timer window open period, use the
+  `::picolibrary::Microchip::megaAVR0::Watchdog_Timer::open_period()` function.
 - To check if a watchdog timer configuration change is in progress, use the
   `::picolibrary::Microchip::megaAVR0::Watchdog_Timer::configuration_change_in_progress()`
   function.

--- a/include/picolibrary/microchip/megaavr0/watchdog_timer.h
+++ b/include/picolibrary/microchip/megaavr0/watchdog_timer.h
@@ -108,6 +108,38 @@ inline void enable( Closed_Period closed_period, Open_Period open_period ) noexc
 }
 
 /**
+ * \brief Get the watchdog timer time-out period.
+ *
+ * \return The watchdog timer time-out period.
+ */
+inline auto period() noexcept -> Period
+{
+    return static_cast<Period>( Peripheral::WDT0::instance().ctrla & Peripheral::WDT::CTRLA::Mask::PERIOD );
+}
+
+/**
+ * \brief Get the watchdog timer window closed period.
+ *
+ * \return The watchdog timer window closed period.
+ */
+inline auto closed_period() noexcept -> Closed_Period
+{
+    return static_cast<Closed_Period>(
+        Peripheral::WDT0::instance().ctrla & Peripheral::WDT::CTRLA::Mask::WINDOW );
+}
+
+/**
+ * \brief Get the watchdog timer window open period.
+ *
+ * \return The watchdog timer window open period.
+ */
+inline auto open_period() noexcept -> Open_Period
+{
+    return static_cast<Open_Period>(
+        Peripheral::WDT0::instance().ctrla & Peripheral::WDT::CTRLA::Mask::PERIOD );
+}
+
+/**
  * \brief Check if a watchdog timer configuration change is in progress.
  *
  * \return true if a watchdog timer configuration change is in progress.


### PR DESCRIPTION
Resolves #907 (Add Microchip megaAVR 0-series watchdog timer period getters).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
